### PR TITLE
fix(/xref:ui): wrap enum values in quotes in "How to cite"

### DIFF
--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -171,9 +171,7 @@ function renderResults(entries, query) {
 function howToCiteIDL(term, entry) {
   const { type, for: forList } = entry;
   if (forList) {
-    return forList.map(f => type === 'enum-value'
-      ? `{{${f}/${term ? '"' + term + '"' : '""'}}}`
-      : `{{${f}/${term ? term : '""'}}}`).join('<br>');
+    return forList.map(f => `{{${f}/${term ? type === "enum-value" ? `"${term}"` : term : '""'}}}`).join('<br>');
   }
   switch (type) {
     case 'exception':

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -152,10 +152,11 @@ function renderResults(entries, query) {
     const cite = metadata.types.idl.has(entry.type)
       ? howToCiteIDL(term, entry)
       : metadata.types.markup.has(entry.type)
-      ? howToCiteMarkup(term, entry)
-      : metadata.types.css.has(entry.type) || metadata.types.http.has(entry.type)
-      ? howToCiteAnchor(term, entry)
-      : howToCiteTerm(term, entry);
+        ? howToCiteMarkup(term, entry)
+        : metadata.types.css.has(entry.type) ||
+            metadata.types.http.has(entry.type)
+          ? howToCiteAnchor(term, entry)
+          : howToCiteTerm(term, entry);
     let row = `
       <tr>
         <td><a href="${link}">${title}</a></td>
@@ -171,7 +172,12 @@ function renderResults(entries, query) {
 function howToCiteIDL(term, entry) {
   const { type, for: forList } = entry;
   if (forList) {
-    return forList.map(f => `{{${f}/${term ? type === "enum-value" ? `"${term}"` : term : '""'}}}`).join('<br>');
+    return forList
+      .map(
+        f =>
+          `{{${f}/${term ? (type === 'enum-value' ? `"${term}"` : term) : '""'}}}`,
+      )
+      .join('<br>');
   }
   switch (type) {
     case 'exception':

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -173,10 +173,10 @@ function howToCiteIDL(term, entry) {
   const { type, for: forList } = entry;
   if (forList) {
     return forList
-      .map(
-        f =>
-          `{{${f}/${term ? (type === 'enum-value' ? `"${term}"` : term) : '""'}}}`,
-      )
+      .map(f => {
+        const termPart = type === 'enum-value' ? `"${term}"` : term;
+        return `{{${f}/${term ? termPart : '""'}}}`;
+      })
       .join('<br>');
   }
   switch (type) {

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -171,7 +171,9 @@ function renderResults(entries, query) {
 function howToCiteIDL(term, entry) {
   const { type, for: forList } = entry;
   if (forList) {
-    return forList.map(f => `{{${f}/${term ? term : '""'}}}`).join('<br>');
+    return forList.map(f => type === 'enum-value'
+      ? `{{${f}/${term ? '"' + term + '"' : '""'}}}`
+      : `{{${f}/${term ? term : '""'}}}`).join('<br>');
   }
   switch (type) {
     case 'exception':


### PR DESCRIPTION
Enum values need to be wrapped in double quotes as described in: https://respec.org/docs/#examples-0

The "How to cite" column listed them without double quotes. This update adds the double quotes when needed.

Note: I haven't managed to run the service locally, so haven't tested the update. I'm happy for anyone to take over and fix this differently ;)