### PR TITLE
fix(utils/DiskCache): better secure path used as cache key

### DIFF
--- a/utils/disk-cache.ts
+++ b/utils/disk-cache.ts
@@ -104,11 +104,14 @@ export class DiskCache<ValueType> {
   }
 
   private keyToFilePath(key: string) {
+    if (!key.startsWith(path.normalize(key))) {
+      throw new Error(`Invalid key: ${key}`);
+    }
     const baseDir = path.join(env("DATA_DIR"), this.#path);
     const result = path.resolve(path.join(baseDir, `${key}.json`));
     // avoid path traversal attack
     if (!result.startsWith(baseDir)) {
-      throw new Error(`Invalid path: ${result}`);
+      throw new Error(`Invalid path: ${key}`);
     }
     return result;
   }


### PR DESCRIPTION
Missed in https://github.com/speced/respec-web-services/pull/440 when testing https://github.com/speced/respec-web-services/pull/435