### PR TITLE
feat(/respec/builds): host latest release from npm

### DIFF
--- a/routes/respec/builds/update.ts
+++ b/routes/respec/builds/update.ts
@@ -10,15 +10,14 @@ export const PKG_DIR = path.join(env("DATA_DIR"), "respec", "package");
 
 export default async function route(req: Request, res: Response) {
   res.type("text/plain");
-  if (typeof req.body.action !== "string") {
+  const action = req.body.action;
+  if (typeof action !== "string") {
     return res.status(400).send("Missing 'action' in body");
   }
-  if (req.body.action !== "released") {
+  if (action !== "released") {
     res.status(400); // Bad request
     res.locals.reason = `action-not-released`;
-    const msg = `Webhook payload was for ${JSON.stringify(
-      req.body.action,
-    )}, ignored.`;
+    const msg = `Webhook payload was for ${JSON.stringify(action)}, ignored.`;
     return res.send(msg);
   }
 

--- a/routes/respec/builds/update.ts
+++ b/routes/respec/builds/update.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { mkdir, readFile } from "node:fs/promises";
+
+import type { Request, Response } from "express";
+
+import { env } from "../../../utils/misc.js";
+import sh from "../../../utils/sh.js";
+
+export const PKG_DIR = path.join(env("DATA_DIR"), "respec", "package");
+
+export default async function route(req: Request, res: Response) {
+  if (req.body.action !== "released") {
+    res.status(400); // Bad request
+    res.locals.reason = `action-not-released`;
+    const msg = `Webhook payload was for ${req.body.action}, ignored.`;
+    return res.send(msg);
+  }
+
+  try {
+    await pullRelease();
+    res.sendStatus(200); // ok
+  } catch (error) {
+    const { message = "", statusCode = 500 } = error;
+    console.error(`Failed to pull respec release: ${message.slice(0, 400)}...`);
+    res.status(statusCode);
+    res.send(message);
+  }
+}
+
+export async function pullRelease() {
+  const start = Date.now();
+  console.log("Pulling latest respec release...");
+
+  const dir = path.resolve(PKG_DIR, "..");
+  await mkdir(dir, { recursive: true });
+  await sh(`npm view respec dist.tarball | xargs curl -s | tar -xz --totals`, {
+    cwd: dir,
+    output: "stream",
+  });
+
+  const { version } = JSON.parse(
+    await readFile(path.join(PKG_DIR, "package.json"), "utf8"),
+  );
+  console.log(
+    `Successfully pulled respec v${version} in ${Date.now() - start}ms.`,
+  );
+}

--- a/routes/respec/builds/update.ts
+++ b/routes/respec/builds/update.ts
@@ -9,6 +9,7 @@ import sh from "../../../utils/sh.js";
 export const PKG_DIR = path.join(env("DATA_DIR"), "respec", "package");
 
 export default async function route(req: Request, res: Response) {
+  res.type("text/plain");
   if (req.body.action !== "released") {
     res.status(400); // Bad request
     res.locals.reason = `action-not-released`;

--- a/routes/respec/builds/update.ts
+++ b/routes/respec/builds/update.ts
@@ -10,10 +10,15 @@ export const PKG_DIR = path.join(env("DATA_DIR"), "respec", "package");
 
 export default async function route(req: Request, res: Response) {
   res.type("text/plain");
+  if (typeof req.body.action !== "string") {
+    return res.status(400).send("Missing 'action' in body");
+  }
   if (req.body.action !== "released") {
     res.status(400); // Bad request
     res.locals.reason = `action-not-released`;
-    const msg = `Webhook payload was for ${req.body.action}, ignored.`;
+    const msg = `Webhook payload was for ${JSON.stringify(
+      req.body.action,
+    )}, ignored.`;
     return res.send(msg);
   }
 

--- a/routes/respec/builds/update.ts
+++ b/routes/respec/builds/update.ts
@@ -18,7 +18,7 @@ export default async function route(req: Request, res: Response) {
     res.status(400); // Bad request
     res.locals.reason = `action-not-released`;
     const msg = `Webhook payload was for ${JSON.stringify(action)}, ignored.`;
-    return res.send(msg);
+    return res.type("text/plain").send(msg);
   }
 
   try {

--- a/routes/respec/index.ts
+++ b/routes/respec/index.ts
@@ -1,6 +1,11 @@
+import path from "node:path";
 import express from "express";
 
+import { env, ms } from "../../utils/misc.js";
+import authGithubWebhook from "../../utils/auth-github-webhook.js";
+
 import * as sizeRoute from "./size.js";
+import buildUpdateRoute, { PKG_DIR } from "./builds/update.js";
 
 const router = express.Router({ mergeParams: true });
 
@@ -9,6 +14,15 @@ router.put(
   "/size",
   express.urlencoded({ extended: false, parameterLimit: 4, limit: "128b" }),
   sizeRoute.put,
+);
+router.use(
+  "/builds",
+  express.static(path.join(PKG_DIR, "builds"), { maxAge: ms("10m") }),
+);
+router.post(
+  "/builds/update",
+  authGithubWebhook(env("RESPEC_SECRET")),
+  buildUpdateRoute,
 );
 
 export default router;

--- a/scripts/update-data-sources.ts
+++ b/scripts/update-data-sources.ts
@@ -3,6 +3,7 @@ import { mkdir } from "fs/promises";
 import { env } from "../utils/misc.js";
 import caniuse from "../routes/caniuse/lib/scraper.js";
 import xref from "../routes/xref/lib/scraper.js";
+import { pullRelease } from "../routes/respec/builds/update.js";
 import w3cGroupsList from "./update-w3c-groups-list.js";
 
 // ensure the data directory exists
@@ -18,4 +19,8 @@ console.groupEnd();
 
 console.group("W3C Groups List");
 await w3cGroupsList();
+console.groupEnd();
+
+console.group("Pull respec release");
+await pullRelease();
 console.groupEnd();


### PR DESCRIPTION
- Latest respec builds to be available under `/respec/builds`, e.g. https://respec.org/respec/builds/respec-w3c.js
- Served with a `max-age=10min`
- Uses webhook event from respec repo (scope: release, action=released) to trigger pull from npm. We create releases in respec manually.