### PR TITLE
fix(/respec/builds): remove CSP/COOP/CORP

### DIFF
--- a/routes/respec/index.ts
+++ b/routes/respec/index.ts
@@ -17,6 +17,12 @@ router.put(
 );
 router.use(
   "/builds",
+  (_req, res, next) => {
+    res.removeHeader("content-security-policy");
+    res.removeHeader("cross-origin-opener-policy");
+    res.removeHeader("cross-origin-resource-policy");
+    next();
+  },
   express.static(path.join(PKG_DIR, "builds"), { maxAge: ms("10m") }),
 );
 router.post(


### PR DESCRIPTION
We set these policies at top-level `app` via `helmet`, which doesn't have a way to undo these headers. So, we remove these headers at route level.