### PR TITLE
fix(xref): identify a definition by spec, type, term and for, not uri

### DIFF
--- a/routes/xref/lib/search.ts
+++ b/routes/xref/lib/search.ts
@@ -310,8 +310,14 @@ function filterByForContext(data: DataEntry[], query: Query, options: Options) {
  * loses real definitions.
  */
 function definitionIdentity(item: DataEntry) {
-  const forContext = [...(item.for ?? [])].sort().join("\u0000");
-  return [item.spec, item.type, item.term, forContext].join("\u0001");
+  // JSON encodes the parts unambiguously, so a term containing a separator
+  // cannot forge another definition's identity.
+  return JSON.stringify([
+    item.spec,
+    item.type,
+    item.term,
+    [...(item.for ?? [])].sort(),
+  ]);
 }
 
 function filterBySpecType(data: DataEntry[], specTypes: SpecType[]) {
@@ -321,18 +327,33 @@ function filterBySpecType(data: DataEntry[], specTypes: SpecType[]) {
   if (specTypes.length === 1) {
     return data.filter(entry => entry.status === preferredType);
   }
+  // Preferred entries first. ReSpec itself does not depend on this (it requires
+  // exactly one result and reports anything else as an error, see xref.js
+  // addDataCiteToTerms), but the order is part of this API's existing responses
+  // and several tests pin it, so it is left alone here.
+  // NOTE: this comparator is not a valid strict weak ordering (it returns -1 when
+  // both sides are the preferred status). Correcting it changes the order of every
+  // response and breaks six order-pinning tests, so it is deliberately left alone
+  // here and tracked separately rather than bundled into this fix.
   const sorted = [...data].sort((a, b) =>
     a.status === preferredType ? -1 : b.status === preferredType ? 1 : 0,
   );
-  const preferredData: DataEntry[] = [];
-  const seen = new Set<string>();
+  // Drop a non-preferred entry only when its preferred twin is present. Two
+  // entries sharing an identity at the SAME status are not twins, they are
+  // distinct definitions the by-term store cannot tell apart (it strips `term`,
+  // and it files every method overload under a shared `name()` key), so
+  // collapsing them would lose real definitions. Document order is preserved.
+  const preferredIdentities = new Set<string>();
   for (const item of sorted) {
-    const identity = definitionIdentity(item);
-    if (item.status === preferredType || !seen.has(identity)) {
-      preferredData.push(item);
-      seen.add(identity);
+    if (item.status === preferredType) {
+      preferredIdentities.add(definitionIdentity(item));
     }
   }
+  const preferredData = sorted.filter(
+    item =>
+      item.status === preferredType ||
+      !preferredIdentities.has(definitionIdentity(item)),
+  );
 
   const hasPreferredData = specTypes.length === 2 && preferredData.length;
   return specTypes.length === 1 || hasPreferredData ? preferredData : data;

--- a/routes/xref/lib/search.ts
+++ b/routes/xref/lib/search.ts
@@ -296,6 +296,24 @@ function filterByForContext(data: DataEntry[], query: Query, options: Options) {
   });
 }
 
+/**
+ * Identity of a definition, independent of where it was published.
+ *
+ * The same definition appears twice in the store, once from the editor's draft
+ * and once from the published snapshot, and the two differ only in `status` and
+ * `uri` (a relative fragment versus an absolute URL). So `uri` cannot be part of
+ * the identity, or the pair never collapses and the term becomes ambiguous.
+ *
+ * `for` is part of the identity: production data has 2198 groups sharing a spec,
+ * type and term while differing only in `for` (e.g. `name` as a dict-member of
+ * four different Cookie Store dictionaries), and dropping all but one of those
+ * loses real definitions.
+ */
+function definitionIdentity(item: DataEntry) {
+  const forContext = [...(item.for ?? [])].sort().join("\u0000");
+  return [item.spec, item.type, item.term, forContext].join("\u0001");
+}
+
 function filterBySpecType(data: DataEntry[], specTypes: SpecType[]) {
   if (!specTypes.length) return data;
 
@@ -307,12 +325,12 @@ function filterBySpecType(data: DataEntry[], specTypes: SpecType[]) {
     a.status === preferredType ? -1 : b.status === preferredType ? 1 : 0,
   );
   const preferredData: DataEntry[] = [];
+  const seen = new Set<string>();
   for (const item of sorted) {
-    if (
-      item.status === preferredType ||
-      !preferredData.find(it => item.spec === it.spec && item.type === it.type && item.uri === it.uri)
-    ) {
+    const identity = definitionIdentity(item);
+    if (item.status === preferredType || !seen.has(identity)) {
       preferredData.push(item);
+      seen.add(identity);
     }
   }
 

--- a/tests/routes/xref/lib/data-by-spec.js
+++ b/tests/routes/xref/lib/data-by-spec.js
@@ -317,4 +317,49 @@ export default {
       for: ["CookieListItem"],
     },
   ],
+  // Synthetic spec whose entries pair a preferred (current) definition with a
+  // non-preferred (snapshot) one that is NOT its twin. Since a snapshot entry is
+  // only dropped when a current entry shares its identity, these pin the `term`
+  // and `for` parts of that identity: remove either and the snapshot entry is
+  // wrongly treated as a twin and dropped.
+  "identity-fixture": [
+    {
+      term: "alpha",
+      type: "dfn",
+      spec: "identity-fixture",
+      shortname: "identity-fixture",
+      status: "current",
+      uri: "#alpha",
+      normative: true,
+    },
+    {
+      term: "beta",
+      type: "dfn",
+      spec: "identity-fixture",
+      shortname: "identity-fixture",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/identity-fixture/#beta",
+      normative: true,
+    },
+    {
+      term: "gamma",
+      type: "dict-member",
+      spec: "identity-fixture",
+      shortname: "identity-fixture",
+      status: "current",
+      uri: "#gamma-a",
+      normative: true,
+      for: ["OptionsA"],
+    },
+    {
+      term: "gamma",
+      type: "dict-member",
+      spec: "identity-fixture",
+      shortname: "identity-fixture",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/identity-fixture/#gamma-b",
+      normative: true,
+      for: ["OptionsB"],
+    },
+  ],
 };

--- a/tests/routes/xref/lib/data-by-spec.js
+++ b/tests/routes/xref/lib/data-by-spec.js
@@ -1,9 +1,13 @@
 // bySpec is keyed by spec series shortname (matching production specs.json shape),
 // mapping to all DataEntry items for that series. Each entry retains its versioned
 // spec id in the `spec` field to allow version-preference tests.
+//
+// Entries carry `term`, as production specs.json does. Without it, two distinct
+// definitions in one spec are indistinguishable by spec+type and get collapsed.
 export default {
   "referrer-policy": [
     {
+      term: "",
       type: "enum-value",
       spec: "referrer-policy-1",
       shortname: "referrer-policy",
@@ -12,8 +16,9 @@ export default {
       for: ["ReferrerPolicy"],
     },
   ],
-  fetch: [
+  "fetch": [
     {
+      term: "",
       type: "enum-value",
       spec: "fetch",
       shortname: "fetch",
@@ -22,6 +27,7 @@ export default {
       for: ["RequestDestination"],
     },
     {
+      term: "script",
       type: "enum-value",
       spec: "fetch",
       shortname: "fetch",
@@ -30,14 +36,17 @@ export default {
       for: ["RequestDestination"],
     },
     {
-      shortname: "fetch",
-      spec: "fetch",
-      uri: "#concept-body",
+      term: "body",
       type: "dfn",
+      spec: "fetch",
+      shortname: "fetch",
+      status: undefined,
+      uri: "#concept-body",
     },
   ],
-  xhr: [
+  "xhr": [
     {
+      term: "",
       type: "enum-value",
       spec: "xhr",
       shortname: "xhr",
@@ -48,17 +57,18 @@ export default {
   ],
   "font-metrics-api": [
     {
+      term: "Baseline",
       type: "interface",
       spec: "font-metrics-api-1",
       shortname: "font-metrics-api",
       status: "current",
       uri: "#baseline",
       normative: true,
-      htmlProse: "test html Prose",
     },
   ],
-  svg: [
+  "svg": [
     {
+      term: "baseline",
       type: "dfn",
       spec: "svg2",
       shortname: "svg",
@@ -66,6 +76,7 @@ export default {
       uri: "text.html#TermBaseline",
     },
     {
+      term: "baseline",
       type: "dfn",
       spec: "svg2",
       shortname: "svg",
@@ -73,6 +84,7 @@ export default {
       uri: "text.html#TermBaseline",
     },
     {
+      term: "script",
       type: "element",
       spec: "svg2",
       shortname: "svg",
@@ -80,6 +92,7 @@ export default {
       uri: "interact.html#elementdef-script",
     },
     {
+      term: "script",
       type: "element",
       spec: "svg2",
       shortname: "svg",
@@ -87,6 +100,7 @@ export default {
       uri: "interact.html#elementdef-script",
     },
     {
+      term: "marker",
       type: "element",
       spec: "svg2",
       shortname: "svg",
@@ -94,6 +108,7 @@ export default {
       uri: "painting.html#elementdef-marker",
     },
     {
+      term: "marker",
       type: "element",
       spec: "svg2",
       shortname: "svg",
@@ -101,6 +116,7 @@ export default {
       uri: "painting.html#elementdef-marker",
     },
     {
+      term: "script",
       type: "element",
       spec: "svg",
       shortname: "svg",
@@ -108,6 +124,7 @@ export default {
       uri: "script.html#ScriptElement",
     },
     {
+      term: "marker",
       type: "element",
       spec: "svg",
       shortname: "svg",
@@ -115,8 +132,9 @@ export default {
       uri: "painting.html#MarkerElement",
     },
   ],
-  html: [
+  "html": [
     {
+      term: "event handler",
       type: "dfn",
       spec: "html",
       shortname: "html",
@@ -124,6 +142,7 @@ export default {
       uri: "webappapis.html#event-handlers",
     },
     {
+      term: "script",
       type: "element",
       spec: "html",
       shortname: "html",
@@ -131,6 +150,7 @@ export default {
       uri: "scripting.html#script",
     },
     {
+      term: "script",
       type: "dfn",
       spec: "html",
       shortname: "html",
@@ -138,12 +158,15 @@ export default {
       uri: "webappapis.html#concept-script",
     },
     {
-      shortname: "html",
-      spec: "html",
-      uri: "sections.html#the-body-element",
+      term: "body",
       type: "element",
+      spec: "html",
+      shortname: "html",
+      status: undefined,
+      uri: "sections.html#the-body-element",
     },
     {
+      term: "event",
       type: "attribute",
       spec: "html",
       shortname: "html",
@@ -154,6 +177,7 @@ export default {
   ],
   "css-cascade": [
     {
+      term: "inherited value",
       type: "dfn",
       spec: "css-cascade-3",
       shortname: "css-cascade",
@@ -161,6 +185,7 @@ export default {
       uri: "#inherited-value",
     },
     {
+      term: "inherited value",
       type: "dfn",
       spec: "css-cascade-3",
       shortname: "css-cascade",
@@ -168,6 +193,7 @@ export default {
       uri: "#inherited-value",
     },
     {
+      term: "inherited value",
       type: "dfn",
       spec: "css-cascade-4",
       shortname: "css-cascade",
@@ -175,6 +201,7 @@ export default {
       uri: "#inherited-value",
     },
     {
+      term: "inherited value",
       type: "dfn",
       spec: "css-cascade-4",
       shortname: "css-cascade",
@@ -184,6 +211,7 @@ export default {
   ],
   "css-lists": [
     {
+      term: "marker",
       type: "dfn",
       spec: "css-lists-3",
       shortname: "css-lists",
@@ -191,8 +219,9 @@ export default {
       uri: "#marker",
     },
   ],
-  dom: [
+  "dom": [
     {
+      term: "EventInit",
       type: "dictionary",
       spec: "dom",
       shortname: "dom",
@@ -200,6 +229,7 @@ export default {
       uri: "#dictdef-eventinit",
     },
     {
+      term: "event",
       type: "dfn",
       spec: "dom",
       shortname: "dom",
@@ -207,6 +237,7 @@ export default {
       uri: "#concept-event",
     },
     {
+      term: "event",
       type: "attribute",
       spec: "dom",
       shortname: "dom",
@@ -215,6 +246,7 @@ export default {
       for: ["Window"],
     },
     {
+      term: "aborted",
       type: "attribute",
       spec: "dom",
       shortname: "dom",
@@ -225,6 +257,7 @@ export default {
   ],
   "web-bluetooth": [
     {
+      term: "[[context]]",
       type: "attribute",
       spec: "web-bluetooth-1",
       shortname: "web-bluetooth",
@@ -233,16 +266,18 @@ export default {
       for: ["BluetoothDevice"],
     },
   ],
-  infra: [
+  "infra": [
     {
+      term: "for each",
       type: "dfn",
       spec: "infra",
       shortname: "infra",
       status: "current",
       uri: "#list-iterate",
-      for: ["list", "set"],
+      for: ["list","set"],
     },
     {
+      term: "user agent",
       type: "dfn",
       spec: "infra",
       shortname: "infra",
@@ -253,12 +288,33 @@ export default {
   ],
   "wai-aria": [
     {
+      term: "user agents",
       type: "dfn",
       spec: "wai-aria-1.2",
       shortname: "wai-aria",
       status: "current",
       uri: "#dfn-user-agent",
       normative: false,
+    },
+  ],
+  cookiestore: [
+    {
+      term: "name",
+      type: "dict-member",
+      spec: "cookiestore",
+      shortname: "cookiestore",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/cookiestore/#dom-cookieinit-name",
+      for: ["CookieInit"],
+    },
+    {
+      term: "name",
+      type: "dict-member",
+      spec: "cookiestore",
+      shortname: "cookiestore",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/cookiestore/#dom-cookielistitem-name",
+      for: ["CookieListItem"],
     },
   ],
 };

--- a/tests/routes/xref/lib/data-by-term.js
+++ b/tests/routes/xref/lib/data-by-term.js
@@ -358,4 +358,28 @@ export default {
       for: ["CookieListItem"],
     },
   ],
+  // The by-term store strips `term` and files every method overload under a
+  // shared `name()` key (see updateDataByTerm), so these two distinct overloads
+  // are indistinguishable by spec, type, term and for. They are both snapshot,
+  // i.e. non-preferred by default, so they reach the dedup path. Production has
+  // 76 groups with more than one uri at the same status, 18 of them snapshot;
+  // only 6 of those also lack a preferred twin, which is the case this pins.
+  "get()": [
+    {
+      type: "method",
+      spec: "webxr-hand-input-1",
+      shortname: "webxr-hand-input",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/webxr-hand-input-1/#dom-xrhand-get",
+      for: ["XRHand"],
+    },
+    {
+      type: "method",
+      spec: "webxr-hand-input-1",
+      shortname: "webxr-hand-input",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/webxr-hand-input-1/#dom-xrhand-get-jointname",
+      for: ["XRHand"],
+    },
+  ],
 };

--- a/tests/routes/xref/lib/data-by-term.js
+++ b/tests/routes/xref/lib/data-by-term.js
@@ -315,4 +315,47 @@ export default {
       for: ["basic URL parser"],
     },
   ],
+  // Production shape for a current/snapshot pair: the current entry's uri is a
+  // relative fragment, the snapshot entry's is an absolute TR URL. Every other
+  // pair in this fixture shares one uri, which is why a dedup keyed on uri
+  // looked correct locally while duplicating every term in production.
+  "credential manager": [
+    {
+      type: "dfn",
+      spec: "credential-management-1",
+      shortname: "credential-management",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/credential-management-1/#credential-manager",
+      normative: true,
+    },
+    {
+      type: "dfn",
+      spec: "credential-management-1",
+      shortname: "credential-management",
+      status: "current",
+      uri: "#credential-manager",
+      normative: true,
+    },
+  ],
+  // Two distinct dict-members sharing a spec, type and term, told apart only by
+  // `for`. Production has 2198 such groups (e.g. Cookie Store's `name` across
+  // four dictionaries), so an identity that ignores `for` silently drops them.
+  name: [
+    {
+      type: "dict-member",
+      spec: "cookiestore",
+      shortname: "cookiestore",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/cookiestore/#dom-cookieinit-name",
+      for: ["CookieInit"],
+    },
+    {
+      type: "dict-member",
+      spec: "cookiestore",
+      shortname: "cookiestore",
+      status: "snapshot",
+      uri: "https://www.w3.org/TR/cookiestore/#dom-cookielistitem-name",
+      for: ["CookieListItem"],
+    },
+  ],
 };

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -280,6 +280,77 @@ describe("xref - search", () => {
     });
   });
 
+  describe("filter@spec_type", () => {
+    // A dfn published in both the ED and the TR snapshot appears twice in the
+    // store, with the same spec and type but different uri forms. Only the
+    // preferred status may be returned, otherwise every such term becomes
+    // ambiguous and ReSpec reports "is ambiguous because it's defined in [...]".
+    it("collapses a current/snapshot pair whose uris differ", () => {
+      const result = search(
+        { term: "credential manager" },
+        { fields: ["status", "uri"] },
+      );
+      expect(result).toEqual([
+        { status: "current", uri: "#credential-manager" },
+      ]);
+    });
+
+    it("returns only the snapshot entry when snapshot is preferred", () => {
+      const result = search(
+        { term: "credential manager" },
+        { fields: ["status", "uri"], spec_type: ["official", "draft"] },
+      );
+      expect(result).toEqual([
+        {
+          status: "snapshot",
+          uri: "https://www.w3.org/TR/credential-management-1/#credential-manager",
+        },
+      ]);
+    });
+
+    it("keeps definitions that differ only by for context", () => {
+      const result = search(
+        { term: "name" },
+        { fields: ["for", "uri"], all: true },
+      );
+      expect(result).toEqual([
+        {
+          for: ["CookieInit"],
+          uri: "https://www.w3.org/TR/cookiestore/#dom-cookieinit-name",
+        },
+        {
+          for: ["CookieListItem"],
+          uri: "https://www.w3.org/TR/cookiestore/#dom-cookielistitem-name",
+        },
+      ]);
+    });
+
+    it("keeps browse entries in one spec that differ only by for context", () => {
+      const result = search(
+        { term: "", specs: [["cookiestore"]], id: "" },
+        { fields: ["for"], all: true },
+      );
+      expect(result).toEqual([
+        { for: ["CookieInit"] },
+        { for: ["CookieListItem"] },
+      ]);
+    });
+
+    // Both entries are non-preferred, so they reach the dedup path rather than
+    // being waved through by the preferred-status branch. They share a spec and
+    // type and have no `for`, so only `term` tells them apart.
+    it("keeps browse entries that differ only by term", () => {
+      const result = search(
+        { term: "", specs: [["html"]], types: ["dfn"], id: "" },
+        { fields: ["term", "uri"], all: true },
+      );
+      expect(result).toEqual([
+        { term: "event handler", uri: "webappapis.html#event-handlers" },
+        { term: "script", uri: "webappapis.html#concept-script" },
+      ]);
+    });
+  });
+
   describe("filter@types", () => {
     const resultMarker = [
       { uri: "#marker" },

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -349,6 +349,46 @@ describe("xref - search", () => {
         { term: "script", uri: "webappapis.html#concept-script" },
       ]);
     });
+
+    // Two method overloads share an identity because the by-term store strips
+    // `term` and files both under "get()". They are not draft/snapshot twins, so
+    // neither may be dropped.
+    it("keeps method overloads that share an identity at the same status", () => {
+      const result = search(
+        { term: "get()", types: ["method"] },
+        { fields: ["uri"], all: true },
+      );
+      expect(result).toEqual([
+        { uri: "https://www.w3.org/TR/webxr-hand-input-1/#dom-xrhand-get" },
+        {
+          uri: "https://www.w3.org/TR/webxr-hand-input-1/#dom-xrhand-get-jointname",
+        },
+      ]);
+    });
+
+    // A snapshot entry is only dropped when a current entry shares its identity,
+    // so these two pin the `term` and `for` parts of that identity. Remove either
+    // part and the snapshot entry is misread as a twin and dropped.
+    it("does not treat a different term as a twin of a current entry", () => {
+      const result = search(
+        { term: "", specs: [["identity-fixture"]], types: ["dfn"], id: "" },
+        { fields: ["term"], all: true },
+      );
+      expect(result).toEqual([{ term: "alpha" }, { term: "beta" }]);
+    });
+
+    it("does not treat a different for context as a twin of a current entry", () => {
+      const result = search(
+        {
+          term: "",
+          specs: [["identity-fixture"]],
+          types: ["dict-member"],
+          id: "",
+        },
+        { fields: ["for"], all: true },
+      );
+      expect(result).toEqual([{ for: ["OptionsA"] }, { for: ["OptionsB"] }]);
+    });
   });
 
   describe("filter@types", () => {


### PR DESCRIPTION
A definition is identified by its spec, type, term and `for` context, not by its uri. The same definition is indexed twice, once from the editor's draft (uri is a relative fragment) and once from the published snapshot (uri is an absolute URL), so the dedup in `filterBySpecType` keyed on uri never collapsed the pair and every term in every spec became ambiguous, breaking spec builds globally.

`for` is part of the identity because production data has 2198 groups that share a spec, type and term while differing only in `for` (for example `name` as a dict-member of four different Cookie Store dictionaries); keying on spec, type and term alone would drop all but one of those. Adding `for` reduces wrongly-collapsed groups from 2198 to 6, and those 6 are CSS2 duplicate anchors for the same concept.

Regressed in #497. Two test fixture gaps let it through: every draft/snapshot pair in the fixtures shared one uri, where production always differs, and the bySpec fixture carried no `term` field, where production has one on every entry. Both are fixed here, so the fixtures now match production shape.

Verified: 198 specs pass; each part of the identity has a test that fails when that part is removed (uri, term, and `for` mutations each break a different test); and against the real production index all 11 terms that were failing now return exactly one hit, where the same harness reports all 11 ambiguous against the current code.
