### PR TITLE
fix(xref): treat an explicit empty-string term as a lookup, not a browse

### DIFF
--- a/routes/xref/lib/search.ts
+++ b/routes/xref/lib/search.ts
@@ -108,7 +108,7 @@ export function searchOne(
   prefereredData = filterPreferLatestVersion(prefereredData);
   // Cap empty-term browsing results after preference filters have run so that
   // preferred entries (e.g. current over snapshot, latest version) are retained.
-  if (query.term === undefined && prefereredData.length > BROWSE_LIMIT) {
+  if (query.term == null && prefereredData.length > BROWSE_LIMIT) {
     prefereredData = prefereredData.slice(0, BROWSE_LIMIT);
   }
   const result = prefereredData.map(item => pickFields(item, options.fields));
@@ -136,7 +136,10 @@ const BROWSE_LIMIT = 1000;
 
 function filter(query: Query, store: Store, options: Options) {
   const searchTerm = query.term;
-  if (searchTerm === undefined) {
+  // `== null` on purpose: a JSON body can carry {"term": null}, and the POST route
+  // passes req.body.queries to searchOne unvalidated. An explicit "" is NOT caught
+  // here, which is the whole point of this function.
+  if (searchTerm == null) {
     // No term at all means "browse everything in these specs". An explicit
     // empty string is NOT this case: it is a real term, so it falls through to
     // the lookup below. Types-only browsing is unsupported (it would scan the

--- a/routes/xref/lib/search.ts
+++ b/routes/xref/lib/search.ts
@@ -43,7 +43,12 @@ export interface Options {
 }
 
 export interface Query {
-  term: string;
+  /**
+   * The term to look up. An explicit empty string is a real term (the
+   * empty-string enum value, which ReSpec writes as `Foo[""]`), so it is NOT
+   * the browse signal. Browsing a whole spec is requested by omitting `term`.
+   */
+  term?: string;
   id: string;
   types?: (Type | "_IDL_" | "_CONCEPT_")[];
   specs?: string[][];
@@ -103,7 +108,7 @@ export function searchOne(
   prefereredData = filterPreferLatestVersion(prefereredData);
   // Cap empty-term browsing results after preference filters have run so that
   // preferred entries (e.g. current over snapshot, latest version) are retained.
-  if (!query.term && prefereredData.length > BROWSE_LIMIT) {
+  if (query.term === undefined && prefereredData.length > BROWSE_LIMIT) {
     prefereredData = prefereredData.slice(0, BROWSE_LIMIT);
   }
   const result = prefereredData.map(item => pickFields(item, options.fields));
@@ -130,14 +135,14 @@ function normalizeQuery(query: Query, options: Options) {
 const BROWSE_LIMIT = 1000;
 
 function filter(query: Query, store: Store, options: Options) {
-  // When no term is provided but specs are, return all entries from those specs.
-  // Types-only browsing (no term, no specs) is deliberately unsupported as it
-  // would require scanning the entire store. The route layer rejects such
-  // requests with a 400. The result limit (BROWSE_LIMIT) is applied after
-  // preference filtering in searchOne() so that filterBySpecType and
-  // filterPreferLatestVersion can properly select preferred entries before
-  // the cap is enforced.
-  if (!query.term && query.specs?.length) {
+  const searchTerm = query.term;
+  if (searchTerm === undefined) {
+    // No term at all means "browse everything in these specs". An explicit
+    // empty string is NOT this case: it is a real term, so it falls through to
+    // the lookup below. Types-only browsing is unsupported (it would scan the
+    // whole store) and the route rejects it with a 400. BROWSE_LIMIT is applied
+    // in searchOne(), after the preference filters have chosen entries.
+    if (!query.specs?.length) return [];
     const entries = collectBySpecs(query.specs, store);
     const byType = filterByType(entries, query);
     return filterByForContext(byType, query, options);
@@ -147,7 +152,7 @@ function filter(query: Query, store: Store, options: Options) {
   const isIDL = types.some(t => IDL_TYPES.has(t));
   const allowCaseFallback = !isIDL;
 
-  for (const term of getTermVariations(query)) {
+  for (const term of getTermVariations(searchTerm, query)) {
     // Try the exact-case bucket first (so `[=baseline=]` and `{{Baseline}}`
     // stay distinct), then a case-insensitive fallback. The fallback is
     // essential when an exact-case bucket exists but every entry is filtered
@@ -206,8 +211,8 @@ function collectBySpecs(specsLists: string[][], store: Store) {
   );
 }
 
-function getTermVariations(query: Query) {
-  const { term: inputTerm, types = [] } = query;
+function getTermVariations(inputTerm: string, query: Query) {
+  const { types = [] } = query;
 
   const isConcept = types.some(t => CONCEPT_TYPES.has(t));
   const isIDL = types.some(t => IDL_TYPES.has(t));

--- a/routes/xref/search.get.ts
+++ b/routes/xref/search.get.ts
@@ -27,7 +27,8 @@ export default async function route(req: IRequest, res: Response) {
     return;
   }
 
-  const query: Query = { term: term ?? "", specs, for: forContext, types, id: "" };
+  // `term` is passed through as-is: undefined means browse, "" is a real term.
+  const query: Query = { term, specs, for: forContext, types, id: "" };
   const options: Partial<Options> = { fields: [], all: !types || !forContext };
 
   const result = searchOne(query, store, options);

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -140,8 +140,15 @@ async function handleSubmit() {
 }
 
 function renderResults(entries, query) {
-  const { term: searchTerm } = query;
-  caption.innerText = searchTerm ? `Searched for "${searchTerm}".` : `Browsing spec definitions.`;
+  // Mirror the service's normalizeQuery: `""` typed in the box means the
+  // empty-string term, so citations and the caption must show "" and not the
+  // two raw quote characters. Browsing is signalled by an omitted term, which is
+  // why this tests for undefined rather than for falsiness.
+  const searchTerm = query.term === '""' ? '' : query.term;
+  caption.innerText =
+    query.term === undefined
+      ? `Browsing spec definitions.`
+      : `Searched for "${searchTerm}".`;
   if (!entries.length) {
     output.innerHTML = `<tr><td colspan="4">No results found.</td></tr>`;
     return;
@@ -149,7 +156,7 @@ function renderResults(entries, query) {
 
   // Detect overloaded IDL entries that would produce identical citations.
   // Build a set of "uri|forContext" pairs for entries that need disambiguation.
-  const overloadedPairs = detectOverloadedEntries(entries, term);
+  const overloadedPairs = detectOverloadedEntries(entries, searchTerm);
 
   let html = '';
   for (const entry of entries) {

--- a/static/xref/script.js
+++ b/static/xref/script.js
@@ -105,7 +105,10 @@ function getFormData() {
   const { values: types } = form.types;
   const { value: forContext } = form.for;
   return {
-    term,
+    // A blank input means "browse these specs", so omit `term` entirely: an
+    // explicit empty string is a real term now (the empty-string enum value).
+    // To search for that term, type "" in the box; normalizeQuery maps it.
+    ...(term !== '' && { term }),
     ...(specs.length && { specs }),
     ...(types.length && { types }),
     ...(forContext && { for: forContext }),
@@ -114,7 +117,7 @@ function getFormData() {
 
 async function handleSubmit() {
   const data = getFormData();
-  if (data.term === '' && !data.specs) return;
+  if (data.term === undefined && !data.specs) return;
 
   const params = new URLSearchParams(Object.entries(data));
   history.replaceState(null, null, `?${params}`);

--- a/tests/routes/xref/lib/data-by-spec.js
+++ b/tests/routes/xref/lib/data-by-spec.js
@@ -15,6 +15,18 @@ export default {
       uri: "#dom-referrerpolicy",
       for: ["ReferrerPolicy"],
     },
+    // A sibling enum-value, as production has (nine of them). Without one, a
+    // browse of this spec and a lookup of the empty-string term both return a
+    // single entry, so a test cannot tell the two code paths apart.
+    {
+      term: "no-referrer",
+      type: "enum-value",
+      spec: "referrer-policy-1",
+      shortname: "referrer-policy",
+      status: "current",
+      uri: "#dom-referrerpolicy-no-referrer",
+      for: ["ReferrerPolicy"],
+    },
   ],
   "fetch": [
     {

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -475,8 +475,8 @@ describe("xref - search", () => {
     });
   });
 
-  describe("empty term with specs (browse all terms)", () => {
-    it("returns all entries for a spec when term is empty", () => {
+  describe("browsing a spec (term omitted)", () => {
+    it("returns all entries for a spec when term is omitted", () => {
       const results = search(
         { specs: [["dom"]], id: "" },
         { all: true },
@@ -523,8 +523,9 @@ describe("xref - search", () => {
       ]);
     });
 
-    it("returns empty when term is empty and no specs are given", () => {
-      // Without specs, empty term should use the normal byTerm[""] path
+    it("returns empty for an empty-string term with no specs", () => {
+      // Without specs an empty-string term is a lookup in byTerm[""], and the
+      // for-scoped entries there are filtered out, so nothing matches.
       const results = search({ term: "", id: "" });
       expect(results).toEqual([]);
     });
@@ -545,6 +546,35 @@ describe("xref - search", () => {
         { fields: ["uri"] },
       );
       expect(results).toEqual([{ uri: "#dom-referrerpolicy" }]);
+    });
+
+    // The lookup must not silently fall back to browsing when the spec has no
+    // empty-string term, or the caller gets the whole spec instead of nothing.
+    it("returns nothing for an empty-string term in a spec that lacks one", () => {
+      const results = search(
+        { term: "", specs: [["dom"]], id: "" },
+        { fields: ["uri"], all: true },
+      );
+      expect(results).toEqual([]);
+    });
+
+    // A null term is reachable: the POST route passes req.body.queries straight
+    // to searchOne with no validation, so it must not throw.
+    it("treats a null term as a browse rather than throwing", () => {
+      expect(() =>
+        search(
+          { term: null, types: ["dfn"], specs: [["dom"]], id: "" },
+          { fields: ["uri"], all: true },
+        ),
+      ).not.toThrow();
+    });
+
+    it("treats a null term with no specs as no results", () => {
+      let results;
+      expect(() => {
+        results = search({ term: null, types: ["dfn"], id: "" }, { all: true });
+      }).not.toThrow();
+      expect(results).toEqual([]);
     });
 
     it("filters by for context when browsing a spec", () => {

--- a/tests/routes/xref/lib/search.test.js
+++ b/tests/routes/xref/lib/search.test.js
@@ -327,7 +327,7 @@ describe("xref - search", () => {
 
     it("keeps browse entries in one spec that differ only by for context", () => {
       const result = search(
-        { term: "", specs: [["cookiestore"]], id: "" },
+        { specs: [["cookiestore"]], id: "" },
         { fields: ["for"], all: true },
       );
       expect(result).toEqual([
@@ -341,7 +341,7 @@ describe("xref - search", () => {
     // type and have no `for`, so only `term` tells them apart.
     it("keeps browse entries that differ only by term", () => {
       const result = search(
-        { term: "", specs: [["html"]], types: ["dfn"], id: "" },
+        { specs: [["html"]], types: ["dfn"], id: "" },
         { fields: ["term", "uri"], all: true },
       );
       expect(result).toEqual([
@@ -371,7 +371,7 @@ describe("xref - search", () => {
     // part and the snapshot entry is misread as a twin and dropped.
     it("does not treat a different term as a twin of a current entry", () => {
       const result = search(
-        { term: "", specs: [["identity-fixture"]], types: ["dfn"], id: "" },
+        { specs: [["identity-fixture"]], types: ["dfn"], id: "" },
         { fields: ["term"], all: true },
       );
       expect(result).toEqual([{ term: "alpha" }, { term: "beta" }]);
@@ -380,7 +380,6 @@ describe("xref - search", () => {
     it("does not treat a different for context as a twin of a current entry", () => {
       const result = search(
         {
-          term: "",
           specs: [["identity-fixture"]],
           types: ["dict-member"],
           id: "",
@@ -479,7 +478,7 @@ describe("xref - search", () => {
   describe("empty term with specs (browse all terms)", () => {
     it("returns all entries for a spec when term is empty", () => {
       const results = search(
-        { term: "", specs: [["dom"]], id: "" },
+        { specs: [["dom"]], id: "" },
         { all: true },
       );
       // dom has: EventInit (dictionary), event (dfn), event (attr for Window),
@@ -489,7 +488,7 @@ describe("xref - search", () => {
 
     it("returns all entries for a spec filtered by type", () => {
       const results = search(
-        { term: "", specs: [["dom"]], types: ["attribute"], id: "" },
+        { specs: [["dom"]], types: ["attribute"], id: "" },
         { all: true },
       );
       expect(results).toEqual([
@@ -500,7 +499,7 @@ describe("xref - search", () => {
 
     it("returns all entries for a spec filtered by aggregate type", () => {
       const results = search(
-        { term: "", specs: [["dom"]], types: ["_IDL_"], id: "" },
+        { specs: [["dom"]], types: ["_IDL_"], id: "" },
         { all: true },
       );
       // _IDL_ includes: dictionary, attribute
@@ -514,7 +513,7 @@ describe("xref - search", () => {
 
     it("returns all enum-values for a spec (issue #278)", () => {
       const results = search(
-        { term: "", specs: [["fetch"]], types: ["enum-value"], id: "" },
+        { specs: [["fetch"]], types: ["enum-value"], id: "" },
         { all: true },
       );
       const sorted = results.sort((a, b) => a.uri.localeCompare(b.uri));
@@ -530,9 +529,26 @@ describe("xref - search", () => {
       expect(results).toEqual([]);
     });
 
+    // `{{ ReferrerPolicy[""] }}` in ReSpec is a lookup of the enum value whose
+    // name is the empty string, and ReSpec sends it as term: "" plus the spec.
+    // It must not be read as "browse this whole spec": ReSpec treats anything
+    // other than exactly one result as an error and leaves the term unlinked.
+    it("treats an explicit empty-string term as a lookup, not a browse", () => {
+      const results = search(
+        {
+          term: "",
+          types: ["enum-value"],
+          for: "ReferrerPolicy",
+          specs: [["referrer-policy"]],
+          id: "",
+        },
+        { fields: ["uri"] },
+      );
+      expect(results).toEqual([{ uri: "#dom-referrerpolicy" }]);
+    });
+
     it("filters by for context when browsing a spec", () => {
       const results = search({
-        term: "",
         specs: [["dom"]],
         for: "Window",
         id: "",
@@ -542,7 +558,7 @@ describe("xref - search", () => {
 
     it("combines multiple specs in a single fallback list", () => {
       const results = search(
-        { term: "", specs: [["css-lists", "web-bluetooth"]], id: "" },
+        { specs: [["css-lists", "web-bluetooth"]], id: "" },
         { all: true },
       );
       expect(results.length).toBeGreaterThan(0);
@@ -553,7 +569,7 @@ describe("xref - search", () => {
       // by series shortname (css-lists, web-bluetooth), so collectBySpecs() must
       // resolve them via specmap to return results.
       const results = search(
-        { term: "", specs: [["css-lists-3", "web-bluetooth-1"]], id: "" },
+        { specs: [["css-lists-3", "web-bluetooth-1"]], id: "" },
         { all: true },
       );
       expect(results.length).toBeGreaterThan(0);


### PR DESCRIPTION
`{{ ReferrerPolicy[""] }}` asks for the enum value whose name is the empty string. ReSpec sends that as `term: ""` together with the spec, and the browse branch added in #497 matched it with `!query.term`, so the service answered with every entry in the spec instead. ReSpec treats anything other than exactly one result as an error, so the term was left unlinked. Measured against production: that query returns 9 hits, while the same query without `specs` returns the correct 1.

Browsing is now requested by omitting `term` entirely, and an explicit empty string is a real term again, which is what it meant before #497. `search.get.ts` no longer coerces a missing term to `""`.

This is what breaks the `links enum and enum-values` test, under `inline IDL references` in the xref suite in speced/respec, with `Expected '' to be 'https://www.w3.org/TR/referrer-policy/#dom-referrerpolicy'`.

Two further defects came out of review and are fixed here as separate commits.

A null term crashed. The POST route passes `req.body.queries` into `searchOne` with no validation, so `{"term": null}` is reachable from outside, and a strict `=== undefined` check let it fall through to `TypeError: Cannot read properties of null (reading 'toLowerCase')`. Browsing now keys on `== null`. On `main` a null term with specs was harmless and a null term without specs already crashed, so this closes that pre-existing case too.

The search UI had two problems. `renderResults` passed an unbound `term` to `detectOverloadedEntries`: #495 added that call when the variable was named `term`, and #497 renamed it to `searchTerm` without updating the call site. The input carries `name="term"` and no `id`, so there is no global to satisfy it. Separately, typing `""` in the box rendered the citation as `{{ReferrerPolicy/""""}}` and the caption as `Searched for """"`, because the raw two-quote value reached `howToCiteIDL`, which wraps `enum-value` terms in quotes. Display now mirrors `normalizeQuery`, and the caption distinguishes an omitted term (browsing) from an empty-string term.

Ripple, all in this PR: the browse tests now omit `term` rather than passing `""`, their names say "omitted" rather than "empty", and the UI omits a blank term (type `""` in the box to search for the empty-string term, which `normalizeQuery` already maps).

Verified against the real xref index: the ReSpec query now returns exactly 1 (`#dom-referrerpolicy`), `no-referrer` still returns 1, and omitting `term` still browses all 9. The new lookup test fails on `main` with 2 hits where 1 is expected, using a fixture that now carries a sibling enum-value so browse and lookup are distinguishable. The null-term tests fail on `main` too. 205 specs pass.

The UI changes have no automated coverage, which is how a `renderResults` that throws survived since #497 landed. The two rendering rules were checked by hand against the real `howToCiteIDL` logic, but nothing in CI exercises that file.
