### PR TITLE
feat(bibrefs): serve specref bibliography data

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -9,6 +9,7 @@ import { register as registerViewEngine } from "./utils/view-engine.js";
 import { PROJECT_ROOT } from "./utils/constants.js";
 
 import xrefRouter from "./routes/xref/index.js";
+import bibrefsRouter from "./routes/bibrefs/index.js";
 import caniuseRouter from "./routes/caniuse/index.js";
 import githubRouter from "./routes/github/index.js";
 import respecRouter from "./routes/respec/index.js";
@@ -47,6 +48,7 @@ app.use(
 );
 
 app.use("/xref", xrefRouter);
+app.use("/bibrefs", bibrefsRouter);
 app.use("/caniuse", caniuseRouter);
 app.use("/api/baseline", baselineRouter);
 app.use("/github/:org/:repo", githubRouter);

--- a/routes/bibrefs/index.ts
+++ b/routes/bibrefs/index.ts
@@ -1,0 +1,104 @@
+import cors from "cors";
+import express, { Request, Response } from "express";
+import rateLimit from "express-rate-limit";
+
+import { ms, seconds } from "../../utils/misc.js";
+import { DATA_FILE } from "./lib/paths.js";
+import { startRefreshing } from "./lib/refresh.js";
+import { store } from "./lib/store-init.js";
+import { isUnsafeKey } from "./lib/validate.js";
+
+const MAX_REFERENCES_PER_REQUEST = 500;
+const CACHE_SECONDS = seconds("1h");
+
+/**
+ * Two limits, because the two answers are wildly different sizes.
+ *
+ * A lookup replies with tens of kilobytes, so it can be generous. The whole
+ * store is 26 MB, and its URL never varies, so a cache in front should absorb
+ * nearly all of it; anything reaching us at volume is abuse, not a spec build.
+ */
+const lookupRateLimit = rateLimit({
+  windowMs: ms("1m"),
+  max: 120,
+  skip: wantsWholeStore,
+});
+const wholeStoreRateLimit = rateLimit({
+  windowMs: ms("1h"),
+  max: 20,
+  skip: request => !wantsWholeStore(request),
+});
+
+const bibrefs = express.Router({ mergeParams: true });
+
+bibrefs
+  .options("/", cors({ methods: ["GET"], maxAge: ms("1day") }))
+  .get("/", cors(), lookupRateLimit, wholeStoreRateLimit, route);
+
+startRefreshing();
+
+export default bibrefs;
+
+export function route(req: Request, res: Response) {
+  if (store.degraded) {
+    // Uncacheable: a cached failure would outlive the recovery.
+    res.locals.reason = "degraded";
+    res.set("Cache-Control", "no-store");
+    res.sendStatus(503);
+    return;
+  }
+
+  if (wantsWholeStore(req)) {
+    res.locals.reason = "whole-store";
+    setCacheHeaders(res);
+    // dotfiles: send() answers 404 for any path with a dot-segment, and
+    // DATA_DIR is free to live under one.
+    res.type("application/json").sendFile(DATA_FILE, { dotfiles: "allow" });
+    return;
+  }
+
+  const requested = requestedReferences(req.query.refs);
+
+  if (requested.length > MAX_REFERENCES_PER_REQUEST) {
+    res.locals.reason = "too-many-references";
+    res.set("Cache-Control", "no-store");
+    res.status(400).json({
+      error: `Too many references: ${requested.length}, the limit is ${MAX_REFERENCES_PER_REQUEST}.`,
+    });
+    return;
+  }
+
+  const body = store.getRefs(requested);
+  Object.assign(res.locals, {
+    queries: requested.length,
+    errors: requested.filter(reference => !Object.hasOwn(body, reference))
+      .length,
+  });
+
+  setCacheHeaders(res);
+  // jsonp, not json: the service this replaces answered `?callback=` with
+  // JSONP, and Express falls back to plain JSON when no callback is named.
+  res.jsonp(body);
+}
+
+/** Only a request with no query string. `?refs=` and `?refs[]=a` leave
+ * `req.query.refs` empty, so testing that instead gives the store away. */
+function wantsWholeStore(req: Request) {
+  return Object.keys(req.query).length === 0;
+}
+
+/** `?refs=A,B&refs=C` becomes ["A", "B", "C"]. */
+function requestedReferences(references: unknown) {
+  const values = Array.isArray(references) ? references : [references];
+  return values
+    .flatMap(value => (typeof value === "string" ? value.split(",") : []))
+    .map(reference => reference.trim())
+    .filter(reference => reference && !isUnsafeKey(reference));
+}
+
+function setCacheHeaders(res: Response) {
+  res.set("Cache-Control", `public, max-age=${CACHE_SECONDS}`);
+  // Keep Expires. ReSpec parses this header itself to decide how long to hold
+  // entries in IndexedDB, so it does more here than ordinary HTTP caching.
+  res.set("Expires", new Date(Date.now() + CACHE_SECONDS * 1000).toUTCString());
+}

--- a/routes/bibrefs/lib/build-data.ts
+++ b/routes/bibrefs/lib/build-data.ts
@@ -1,0 +1,95 @@
+// Spawned by lib/scraper.ts as its own process, because the transform it runs
+// peaks near 560 MB and a worker thread would charge that to the server.
+//
+// Runnable by hand to rebuild the data file without restarting the server:
+//   node build/routes/bibrefs/lib/build-data.js <cloneDirectory> <outputFile>
+
+import { createRequire } from "node:module";
+import {
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { PROJECT_ROOT } from "../../../utils/constants.js";
+import { validate } from "./validate.js";
+
+const VENDOR_DIRECTORY = path.join(PROJECT_ROOT, "vendor", "specref");
+const TRANSFORM = "bibref.js";
+const VENDORED_FILES = [TRANSFORM, "format-date.js"];
+
+/** Symlinks survive a clone, and the transform reads every file in here. */
+function assertEveryInputIsAPlainJsonFile(directory: string) {
+  const rejected = readdirSync(directory).filter(
+    name =>
+      !name.endsWith(".json") ||
+      !lstatSync(path.join(directory, name)).isFile(),
+  );
+  if (rejected.length) {
+    throw new Error(
+      `Refusing to build, these are not plain .json files: ${rejected.join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Build a directory we own for the transform to run in, and return the file to
+ * require.
+ *
+ * The transform reads its input from `__dirname/../refs`, so it needs a parent
+ * holding both. Nothing is written inside the clone: every path there belongs to
+ * upstream, and a committed symlink would otherwise let a copy land wherever it
+ * pointed.
+ */
+function prepareWorkspace(cloneDirectory: string, outputFile: string) {
+  const workspace = path.join(path.dirname(outputFile), "transform");
+  rmSync(workspace, { recursive: true, force: true });
+  mkdirSync(path.join(workspace, "lib"), { recursive: true });
+  for (const name of VENDORED_FILES) {
+    copyFileSync(
+      path.join(VENDOR_DIRECTORY, name),
+      path.join(workspace, "lib", name),
+    );
+  }
+  symlinkSync(path.join(cloneDirectory, "refs"), path.join(workspace, "refs"));
+  return path.join(workspace, "lib", TRANSFORM);
+}
+
+function build(cloneDirectory: string, outputFile: string) {
+  assertEveryInputIsAPlainJsonFile(path.join(cloneDirectory, "refs"));
+  const transform = prepareWorkspace(cloneDirectory, outputFile);
+  const bibref = createRequire(import.meta.url)(transform);
+  const references = bibref.all;
+
+  // The transform keeps its merged input and a reverse-lookup index alive next
+  // to the result. Nothing here reads either, and together they are most of the
+  // peak this process reaches.
+  bibref.raw = null;
+  bibref.reverseLookupTable = null;
+
+  const problem = validate(references);
+  if (problem) throw new Error(`Refusing to publish: ${problem}.`);
+
+  // Rename, so a crash mid-write cannot leave a truncated file to load at boot.
+  const temporary = `${outputFile}.incoming`;
+  writeFileSync(temporary, JSON.stringify(references), "utf8");
+  renameSync(temporary, outputFile);
+  return Object.keys(references).length;
+}
+
+const [cloneDirectory, outputFile] = process.argv.slice(2);
+if (!cloneDirectory || !outputFile) {
+  console.error("usage: build-data.js <cloneDirectory> <outputFile>");
+  process.exit(1);
+}
+const count = build(cloneDirectory, outputFile);
+const peakMegabytes = Math.round(process.memoryUsage().rss / 1024 / 1024);
+console.log(
+  `Wrote ${count} references to ${outputFile} (peak ${peakMegabytes} MB)`,
+);

--- a/routes/bibrefs/lib/paths.ts
+++ b/routes/bibrefs/lib/paths.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+
+import { env } from "../../../utils/misc.js";
+
+/** Absolute: res.sendFile throws on a relative path. */
+export const DATA_FILE = path.resolve(
+  env("DATA_DIR"),
+  "bibrefs",
+  "biblio.json",
+);

--- a/routes/bibrefs/lib/refresh.ts
+++ b/routes/bibrefs/lib/refresh.ts
@@ -1,0 +1,22 @@
+import { ms } from "../../../utils/misc.js";
+
+import scraper from "./scraper.js";
+import { store } from "./store-init.js";
+
+/** Polling, because we do not own tobie/specref. A webhook would need Tobie to add one. */
+async function tick() {
+  try {
+    // forceUpdate when degraded: otherwise an unchanged upstream means the
+    // scraper returns false and a store that rejected its file never retries.
+    if (await scraper({ forceUpdate: store.degraded })) store.fill();
+  } catch (error) {
+    console.warn("bibrefs: refresh failed, will try again next hour.", error);
+  } finally {
+    startRefreshing();
+  }
+}
+
+/** setTimeout, not setInterval: a slow run must not overlap the next one. */
+export function startRefreshing() {
+  setTimeout(tick, ms("1h")).unref();
+}

--- a/routes/bibrefs/lib/scraper.ts
+++ b/routes/bibrefs/lib/scraper.ts
@@ -1,0 +1,114 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { env, ms } from "../../../utils/misc.js";
+
+import { DATA_FILE } from "./paths.js";
+
+const run = promisify(execFile);
+
+const UPSTREAM_REPOSITORY = "https://github.com/tobie/specref.git";
+const CLONE_DIRECTORY = path.resolve(env("DATA_DIR"), "specref");
+
+const GIT_TIMEOUT = ms("10m");
+const BUILD_TIMEOUT = ms("2m");
+// Keep this. A smaller old-generation budget makes V8 collect sooner, which
+// measurably lowers the peak resident memory of a build that runs beside the
+// server on a host with about a gigabyte.
+const BUILD_HEAP_MB = 512;
+const defaultOptions = { forceUpdate: false };
+type Options = typeof defaultOptions;
+
+/**
+ * The commit whose data we last wrote out successfully.
+ *
+ * Compared against, rather than "did the clone move", so a build that fails
+ * after the clone has already advanced gets retried instead of being treated as
+ * up to date until upstream happens to commit again.
+ */
+let lastPublishedCommit: string | null = null;
+
+export default async function main(options: Partial<Options> = {}) {
+  const { forceUpdate } = { ...defaultOptions, ...options };
+  const commit = await updateInputSource();
+  if (!forceUpdate && commit === lastPublishedCommit && existsSync(DATA_FILE)) {
+    console.log("Nothing to update from specref.");
+    return false;
+  }
+  await mkdir(path.dirname(DATA_FILE), { recursive: true });
+  await buildData();
+  lastPublishedCommit = commit;
+  return true;
+}
+
+/**
+ * execFile, not utils/sh.ts: that one runs a shell, so anything interpolated
+ * into the command is injectable. The env is an allowlist because the default
+ * hands the child GH_TOKEN and every webhook secret.
+ */
+function git(gitArguments: string[], workingDirectory: string) {
+  const { PATH, HOME } = process.env;
+  return run("git", gitArguments, {
+    cwd: workingDirectory,
+    timeout: GIT_TIMEOUT,
+    env: { PATH, HOME, GIT_TERMINAL_PROMPT: "0" },
+  });
+}
+
+async function head() {
+  const { stdout } = await git(["rev-parse", "HEAD"], CLONE_DIRECTORY);
+  return stdout.trim();
+}
+
+async function clone() {
+  await mkdir(path.dirname(CLONE_DIRECTORY), { recursive: true });
+  // Shallow: nothing reads the history, and it is 638 MB of objects.
+  await git(
+    ["clone", "--depth", "1", UPSTREAM_REPOSITORY, CLONE_DIRECTORY],
+    path.dirname(CLONE_DIRECTORY),
+  );
+}
+
+/** @returns the commit the clone now sits at. */
+async function updateInputSource() {
+  if (!existsSync(CLONE_DIRECTORY)) {
+    await clone();
+    return head();
+  }
+  try {
+    await git(["fetch", "--depth", "1", "origin", "main"], CLONE_DIRECTORY);
+    await git(["reset", "--hard", "FETCH_HEAD"], CLONE_DIRECTORY);
+    await git(["clean", "-fd"], CLONE_DIRECTORY);
+    return await head();
+  } catch (error) {
+    // An interrupted fetch leaves an index.lock that fails every later run, and
+    // an interrupted clone leaves a directory that is not a repository at all.
+    // Reading the commit inside this block is what lets the second case recover.
+    console.warn(
+      "specref: git failed, discarding the clone and starting over.",
+      error,
+    );
+    await rm(CLONE_DIRECTORY, { recursive: true, force: true });
+    await clone();
+    return head();
+  }
+}
+
+/** Its own process: a worker thread shares this process's resident memory, and the transform peaks near 560 MB. */
+async function buildData() {
+  const script = path.join(import.meta.dirname, "build-data.js");
+  const { stdout } = await run(
+    process.execPath,
+    [
+      `--max-old-space-size=${BUILD_HEAP_MB}`,
+      script,
+      CLONE_DIRECTORY,
+      DATA_FILE,
+    ],
+    { timeout: BUILD_TIMEOUT },
+  );
+  console.log(stdout.trim());
+}

--- a/routes/bibrefs/lib/store-init.ts
+++ b/routes/bibrefs/lib/store-init.ts
@@ -1,0 +1,3 @@
+import { Store } from "./store.js";
+
+export const store = new Store();

--- a/routes/bibrefs/lib/store.ts
+++ b/routes/bibrefs/lib/store.ts
@@ -1,0 +1,99 @@
+import { readFileSync, statSync } from "node:fs";
+
+import { DATA_FILE } from "./paths.js";
+import { isUnsafeKey, Reference, References, validate } from "./validate.js";
+
+export class Store {
+  /** Set until `fill` accepts a data file. The route answers 503 while it is. */
+  degraded = true;
+  dataWrittenAt: Date | null = null;
+  references: References = {};
+  /** Do not make this a getter: /monitor/usage reads it on every request. */
+  entries = 0;
+
+  constructor() {
+    this.fill();
+  }
+
+  fill() {
+    let incoming: unknown;
+    try {
+      incoming = JSON.parse(readFileSync(DATA_FILE, "utf8"));
+    } catch (error) {
+      console.warn(
+        `bibrefs: cannot read ${DATA_FILE}, keeping existing data.`,
+        error,
+      );
+      return;
+    }
+
+    const problem = validate(incoming);
+    if (problem) {
+      console.warn(
+        `bibrefs: rejected new data (${problem}), keeping existing data.`,
+      );
+      return;
+    }
+
+    this.references = incoming as References;
+    this.entries = Object.keys(this.references).length;
+    this.dataWrittenAt = statSync(DATA_FILE).mtime;
+    this.degraded = false;
+  }
+
+  getRefs(keys: string[]) {
+    return getRefs(this.references, keys);
+  }
+}
+
+/**
+ * Look up each key and return everything needed to render it: the entries along
+ * its chain of aliases, and the parent it is a version of. A key that is absent
+ * but whose upper-case form exists gets an alias record made for it, so
+ * `[[webidl]]` finds the entry stored under `WEBIDL`. Unknown keys are left out.
+ */
+export function getRefs(references: References, keys: string[]): References {
+  // No prototype while it is being filled, so assigning a key can never
+  // re-point one. Safe only because collect refuses the keys that would
+  // otherwise land here as real properties.
+  const output: References = Object.create(null);
+  for (const key of keys) collect(references, key, output);
+  // Copy before returning. An object built by assigning keys one at a time ends
+  // up in V8's dictionary mode; the copy hands back one with fast properties,
+  // which JSON.stringify serializes faster.
+  return { ...output };
+}
+
+function collect(references: References, key: string, output: References) {
+  if (isUnsafeKey(key)) return;
+  let reference = key;
+  let entry: Reference | undefined;
+  const seen = new Set<string>();
+
+  while (!seen.has(reference)) {
+    seen.add(reference);
+    // Object.hasOwn, not a truthiness test: a caller may ask for a reference
+    // named `constructor` or `toString`, which every plain object inherits.
+    entry = Object.hasOwn(references, reference)
+      ? references[reference]
+      : undefined;
+    const upper = reference.toUpperCase();
+    if (
+      !entry &&
+      !Object.hasOwn(output, reference) &&
+      Object.hasOwn(references, upper)
+    ) {
+      output[reference] = { aliasOf: upper, id: reference };
+      reference = upper;
+      entry = references[reference];
+    }
+    if (entry && !Object.hasOwn(output, reference)) output[reference] = entry;
+    if (!entry?.aliasOf || isUnsafeKey(entry.aliasOf)) break;
+    reference = entry.aliasOf;
+  }
+
+  const parent = entry?.versionOf;
+  if (parent && !isUnsafeKey(parent) && Object.hasOwn(references, parent)) {
+    output[parent] = references[parent];
+  }
+}

--- a/routes/bibrefs/lib/validate.ts
+++ b/routes/bibrefs/lib/validate.ts
@@ -1,0 +1,65 @@
+export interface Reference {
+  id?: string;
+  aliasOf?: string;
+  versionOf?: string;
+  title?: string;
+  href?: string;
+  [key: string]: unknown;
+}
+
+export type References = Record<string, Reference>;
+
+/**
+ * Reject a data file holding fewer references than this.
+ *
+ * The real database holds around 150,000, so this is a floor for spotting a
+ * truncated or half-written build rather than a meaningful lower bound on the
+ * data itself.
+ */
+export const SMALLEST_PLAUSIBLE_DATABASE = 80_000;
+
+/**
+ * Reference identifiers we refuse to look up or to answer with.
+ *
+ * Assigning one of these onto a response object either re-points its prototype
+ * or, on a null-prototype object, becomes a real key the client receives. The
+ * upstream data could carry `aliasOf: "__proto__"` as easily as a caller could
+ * ask for it, so this is checked at both ends.
+ */
+const UNSAFE_KEY = /^(?:__proto__|constructor|prototype)$/i;
+
+export function isUnsafeKey(key: string) {
+  return UNSAFE_KEY.test(key);
+}
+
+const SENTINELS = ["WEBIDL", "rfc2119", "HTML", "rfc5234"];
+
+const SENTINEL_ALIASES = [
+  ["ABNF", "RFC5234"],
+  ["RFC5234", "rfc5234"],
+];
+
+/** @returns a reason to reject the data, or null if it is fit to serve. */
+export function validate(data: unknown): string | null {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return "not a plain object";
+  }
+  const references = data as References;
+  const size = Object.keys(references).length;
+  if (size < SMALLEST_PLAUSIBLE_DATABASE)
+    return `only ${size} references, expected ${SMALLEST_PLAUSIBLE_DATABASE}+`;
+
+  for (const id of SENTINELS) {
+    const entry = references[id];
+    if (typeof entry?.href !== "string" || typeof entry?.title !== "string") {
+      return `sentinel ${id} is missing or malformed`;
+    }
+  }
+
+  for (const [id, target] of SENTINEL_ALIASES) {
+    if (references[id]?.aliasOf !== target)
+      return `alias chain broken at ${id}`;
+  }
+
+  return null;
+}

--- a/routes/monitor/usage.ts
+++ b/routes/monitor/usage.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import path from "path";
 
 import { PROJECT_ROOT } from "../../utils/constants.js";
+import { store as bibrefs } from "../bibrefs/lib/store-init.js";
 
 let version = "unknown";
 try {
@@ -25,5 +26,10 @@ export default function route(_req: Request, res: Response) {
     uptime: process.uptime(),
     heapUsed,
     heapTotal,
+    bibrefs: {
+      updatedAt: bibrefs.dataWrittenAt?.toISOString() ?? null,
+      entries: bibrefs.entries,
+      degraded: bibrefs.degraded,
+    },
   });
 }

--- a/scripts/update-data-sources.ts
+++ b/scripts/update-data-sources.ts
@@ -4,6 +4,7 @@ import caniuse from "../routes/caniuse/lib/scraper.js";
 import xref from "../routes/xref/lib/scraper.js";
 import baseline from "../routes/api/baseline/lib/scraper.js";
 import unicode from "../routes/api/unicode/lib/scraper.js";
+import bibrefs from "../routes/bibrefs/lib/scraper.js";
 import { pullRelease } from "../routes/respec/builds/update.js";
 import w3cGroupsList from "./update-w3c-groups-list.js";
 
@@ -24,6 +25,10 @@ console.groupEnd();
 
 console.group("unicode");
 await unicode({ forceUpdate: true });
+console.groupEnd();
+
+console.group("bibrefs");
+await bibrefs({ forceUpdate: true });
 console.groupEnd();
 
 console.group("W3C Groups List");

--- a/tests/routes/bibrefs/rate-limit.test.js
+++ b/tests/routes/bibrefs/rate-limit.test.js
@@ -1,0 +1,109 @@
+import bibrefs from "../../../build/routes/bibrefs/index.js";
+import { store } from "../../../build/routes/bibrefs/lib/store-init.js";
+
+/**
+ * Drives the real router, middleware included, because the rate limits live in
+ * middleware that calling the handler directly would skip.
+ */
+function send(query, ip) {
+  return new Promise(resolve => {
+    const res = {
+      locals: {},
+      statusCode: 200,
+      headersSent: false,
+      set() {
+        return this;
+      },
+      setHeader() {
+        return this;
+      },
+      getHeader() {},
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      sendStatus(code) {
+        this.statusCode = code;
+        resolve(this);
+        return this;
+      },
+      json() {
+        resolve(this);
+        return this;
+      },
+      jsonp() {
+        resolve(this);
+        return this;
+      },
+      send() {
+        resolve(this);
+        return this;
+      },
+      type() {
+        return this;
+      },
+      sendFile() {
+        this.sentFile = true;
+        resolve(this);
+        return this;
+      },
+      end() {
+        resolve(this);
+        return this;
+      },
+    };
+    const req = {
+      method: "GET",
+      url: "/",
+      originalUrl: "/bibrefs",
+      query,
+      ip,
+      ips: [],
+      headers: {},
+      get: () => undefined,
+      app: { get: () => undefined },
+    };
+    bibrefs(req, res, () => resolve(res));
+  });
+}
+
+/** @returns the 1-based request number that first got a 429, or null. */
+async function firstRejection(query, ip, attempts) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const { statusCode } = await send(query, ip);
+    if (statusCode === 429) return attempt;
+  }
+  return null;
+}
+
+describe("routes/bibrefs - rate limits", () => {
+  beforeEach(() => {
+    store.degraded = false;
+    store.references = { WEBIDL: { title: "Web IDL", id: "WEBIDL" } };
+  });
+
+  afterEach(() => {
+    store.degraded = true;
+    store.references = {};
+  });
+
+  // Each spec needs its own address: the limiter counts per address and its
+  // state outlives a spec.
+  it("cuts off whole-store requests well before a lookup would be cut off", async () => {
+    expect(await firstRejection({}, "203.0.113.1", 25)).toBe(21);
+  });
+
+  it("does not spend the whole-store budget on lookups", async () => {
+    expect(
+      await firstRejection({ refs: "WEBIDL" }, "203.0.113.2", 30),
+    ).toBeNull();
+  });
+
+  it("keeps the two budgets independent", async () => {
+    const address = "203.0.113.3";
+    // Spend the whole-store budget, then show the lookup budget is untouched:
+    // the first lookup refused is still the one past the lookup limit itself.
+    expect(await firstRejection({}, address, 21)).toBe(21);
+    expect(await firstRejection({ refs: "WEBIDL" }, address, 121)).toBe(121);
+  });
+});

--- a/tests/routes/bibrefs/route.test.js
+++ b/tests/routes/bibrefs/route.test.js
@@ -1,0 +1,167 @@
+import { route } from "../../../build/routes/bibrefs/index.js";
+import { store } from "../../../build/routes/bibrefs/lib/store-init.js";
+import { DATA_FILE } from "../../../build/routes/bibrefs/lib/paths.js";
+
+/** @returns {import("express").Response} */
+function makeRes() {
+  return {
+    locals: {},
+    _status: 200,
+    _body: undefined,
+    _headers: {},
+    _sentFile: undefined,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    sendStatus(code) {
+      this._status = code;
+      return this;
+    },
+    set(name, value) {
+      this._headers[name] = value;
+      return this;
+    },
+    json(data) {
+      this._body = data;
+      return this;
+    },
+    jsonp(data) {
+      this._body = data;
+      this._usedJsonp = true;
+      return this;
+    },
+    type() {
+      return this;
+    },
+    sendFile(filePath) {
+      this._sentFile = filePath;
+      return this;
+    },
+  };
+}
+
+function call(query) {
+  const res = makeRes();
+  route({ query }, res);
+  return res;
+}
+
+describe("routes/bibrefs - route", () => {
+  beforeEach(() => {
+    store.degraded = false;
+    store.references = {
+      WEBIDL: {
+        title: "Web IDL",
+        href: "https://example.com/webidl",
+        id: "WEBIDL",
+      },
+    };
+  });
+
+  afterEach(() => {
+    store.degraded = true;
+    store.references = {};
+  });
+
+  it("answers with the entries it found, and cache headers ReSpec can read", () => {
+    const res = call({ refs: "WEBIDL" });
+    // A literal, not store.references.WEBIDL: comparing against the object the
+    // module hands back would pass even if it mutated the entry on the way out.
+    expect(res._body).toEqual({
+      WEBIDL: {
+        title: "Web IDL",
+        href: "https://example.com/webidl",
+        id: "WEBIDL",
+      },
+    });
+    expect(res._headers["Cache-Control"]).toBe("public, max-age=3600");
+    // Parsed, not merely present: an empty Expires satisfies toBeDefined.
+    const expires = Date.parse(res._headers["Expires"]);
+    expect(expires).not.toBeNaN();
+    expect(Math.abs(expires - (Date.now() + 3600_000))).toBeLessThan(60_000);
+    expect(res.locals.reason).toBeUndefined();
+  });
+
+  const counted = [
+    ["one key it has", "WEBIDL", { queries: 1, errors: 0 }],
+    ["a key it does not have", "WEBIDL,NOPE", { queries: 2, errors: 1 }],
+    [
+      "a repeated query parameter",
+      ["WEBIDL", "NOPE"],
+      { queries: 2, errors: 1 },
+    ],
+    [
+      "a comma separated list inside a repeated parameter",
+      ["WEBIDL,NOPE", "ALSO-NOPE"],
+      { queries: 3, errors: 2 },
+    ],
+    [
+      "references padded with spaces",
+      " WEBIDL , NOPE ",
+      { queries: 2, errors: 1 },
+    ],
+  ];
+  for (const [description, refs, expected] of counted) {
+    it(`counts queries and misses for ${description}`, () => {
+      expect(call({ refs }).locals).withContext(description).toEqual(expected);
+    });
+  }
+
+  const counts = [
+    ["exactly the limit", 500, 200],
+    ["one over the limit", 501, 400],
+  ];
+  for (const [description, count, status] of counts) {
+    it(`answers ${status} for ${description}`, () => {
+      const refs = Array.from({ length: count }, (_, i) => `K${i}`).join(",");
+      const res = call({ refs });
+      expect(res._status).withContext(description).toBe(status);
+      if (status === 400) {
+        expect(res._headers["Cache-Control"]).toBe("no-store");
+        expect(res.locals.reason).toBe("too-many-references");
+      }
+    });
+  }
+
+  it("sends the whole database only for a bare GET, as Bikeshed expects", () => {
+    // The exact path: a tail-anchored match passes for the wrong directory.
+    expect(call({})._sentFile).toBe(DATA_FILE);
+    expect(call({}).locals.reason).toBe("whole-store");
+  });
+
+  const notBare = [
+    ["an empty refs parameter", { refs: "" }],
+    ["a refs parameter under another name", { "refs[]": "WEBIDL" }],
+  ];
+  for (const [description, query] of notBare) {
+    it(`does not send the whole 26 MB database for ${description}`, () => {
+      const res = call(query);
+      expect(res._sentFile).withContext(description).toBeUndefined();
+      expect(res._body).toEqual({});
+    });
+  }
+
+  it("answers through jsonp, which the service this replaces supported", () => {
+    // Express falls back to plain JSON when no callback is named, so this only
+    // pins that the route does not use res.json and lose ?callback= support.
+    expect(call({ refs: "WEBIDL" })._usedJsonp).toBe(true);
+  });
+
+  it("blocks prototype keys whatever their case", () => {
+    store.references["__PROTO__"] = {
+      title: "hostile",
+      href: "https://example.com/x",
+    };
+    expect(call({ refs: "__PROTO__" })._body).toEqual({});
+    expect(call({ refs: "__proto__" })._body).toEqual({});
+  });
+
+  it("refuses to serve, uncacheably, while the store is degraded", () => {
+    store.degraded = true;
+    const res = call({ refs: "WEBIDL" });
+    expect(res._status).toBe(503);
+    expect(res.locals.reason).toBe("degraded");
+    expect(res._headers["Cache-Control"]).toBe("no-store");
+  });
+});

--- a/tests/routes/bibrefs/store.test.js
+++ b/tests/routes/bibrefs/store.test.js
@@ -1,0 +1,194 @@
+import { getRefs } from "../../../build/routes/bibrefs/lib/store.js";
+import {
+  validate,
+  SMALLEST_PLAUSIBLE_DATABASE,
+} from "../../../build/routes/bibrefs/lib/validate.js";
+
+/** Enough entries to clear the store's minimum-size check. */
+function bulk() {
+  const references = {
+    WEBIDL: {
+      href: "https://webidl.spec.whatwg.org/",
+      title: "Web IDL Standard",
+    },
+    rfc2119: {
+      href: "https://www.rfc-editor.org/info/rfc2119/",
+      title: "Key words",
+    },
+    HTML: {
+      href: "https://html.spec.whatwg.org/multipage/",
+      title: "HTML Standard",
+    },
+    ABNF: { aliasOf: "RFC5234" },
+    RFC5234: { aliasOf: "rfc5234" },
+    rfc5234: {
+      href: "https://www.rfc-editor.org/info/rfc5234/",
+      title: "ABNF",
+    },
+  };
+  for (
+    let i = Object.keys(references).length;
+    i < SMALLEST_PLAUSIBLE_DATABASE;
+    i++
+  ) {
+    references[`FILLER-${i}`] = {
+      href: `https://example.com/${i}`,
+      title: `Filler ${i}`,
+    };
+  }
+  return references;
+}
+
+describe("routes/bibrefs - getRefs", () => {
+  const references = {
+    ABNF: { aliasOf: "RFC5234", id: "ABNF" },
+    RFC5234: { aliasOf: "rfc5234", id: "RFC5234" },
+    rfc5234: {
+      title: "ABNF",
+      href: "https://example.com/rfc5234",
+      id: "rfc5234",
+    },
+    WEBIDL: {
+      title: "Web IDL",
+      href: "https://example.com/webidl",
+      id: "WEBIDL",
+    },
+    "WEBIDL-20161215": {
+      title: "Web IDL",
+      versionOf: "WEBIDL",
+      id: "WEBIDL-20161215",
+    },
+    x: { aliasOf: "X", id: "x" },
+    X: { aliasOf: "x", id: "X" },
+  };
+
+  // Whole objects, not just key names: asserting the keys alone would pass even
+  // if every value came back null.
+  const cases = [
+    [
+      "emits every entry along an alias chain",
+      ["ABNF"],
+      {
+        ABNF: references.ABNF,
+        RFC5234: references.RFC5234,
+        rfc5234: references.rfc5234,
+      },
+    ],
+    [
+      "emits the versionOf parent",
+      ["WEBIDL-20161215"],
+      {
+        "WEBIDL-20161215": references["WEBIDL-20161215"],
+        WEBIDL: references.WEBIDL,
+      },
+    ],
+    [
+      "resolves a lower-case citation via its upper-case key",
+      ["webidl"],
+      {
+        webidl: { aliasOf: "WEBIDL", id: "webidl" },
+        WEBIDL: references.WEBIDL,
+      },
+    ],
+    ["omits a key it does not have", ["NOPE"], {}],
+    [
+      "ignores keys named after inherited properties",
+      ["toString", "__proto__"],
+      {},
+    ],
+    [
+      "answers with one entry per key when two keys share a chain",
+      ["ABNF", "RFC5234"],
+      {
+        ABNF: references.ABNF,
+        RFC5234: references.RFC5234,
+        rfc5234: references.rfc5234,
+      },
+    ],
+    [
+      "answers for a pair of aliases that point at each other",
+      ["x"],
+      { x: references.x, X: references.X },
+    ],
+  ];
+
+  for (const [description, keys, expected] of cases) {
+    it(description, () => {
+      expect(getRefs(references, keys))
+        .withContext(keys.join(","))
+        .toEqual(expected);
+    });
+  }
+
+  it("walks a long chain to the end instead of truncating it", () => {
+    const chain = {};
+    for (let i = 0; i < 40; i++) chain[`a${i}`] = { aliasOf: `a${i + 1}` };
+    chain.a40 = { title: "end", href: "https://example.com/end" };
+    const output = getRefs(chain, ["a0"]);
+    expect(Object.keys(output).length).toBe(41);
+    expect(output.a40).toEqual(chain.a40);
+  });
+
+  // The data can carry a pointer to a prototype property as easily as a caller
+  // can ask for one, so both pointer kinds are checked.
+  for (const pointer of ["aliasOf", "versionOf"]) {
+    it(`refuses a poisoned ${pointer} rather than answering with it`, () => {
+      const poisoned = JSON.parse(
+        `{"SEEMS-FINE":{"${pointer}":"__proto__"},"__proto__":{"title":"hostile"}}`,
+      );
+      const output = getRefs(poisoned, ["SEEMS-FINE"]);
+      expect(Object.keys(output)).toEqual(["SEEMS-FINE"]);
+      expect(JSON.stringify(output)).not.toContain("hostile");
+    });
+  }
+
+  it("does not put __proto__ on the wire", () => {
+    // An object literal would set the prototype; JSON.parse makes a real own key.
+    const hostile = JSON.parse('{"__proto__":{"title":"hostile"}}');
+    const output = getRefs(hostile, ["__proto__"]);
+    expect(JSON.stringify(output)).toBe("{}");
+    expect({}.title).toBeUndefined();
+  });
+});
+
+describe("routes/bibrefs - validate", () => {
+  const valid = bulk();
+
+  // Each case asserts WHICH check fired: "not null" alone passes when a later
+  // check happens to catch the same fixture, which hides a deleted one.
+  const rejected = [
+    ["an array", [], "not a plain object"],
+    ["a primitive", "nope", "not a plain object"],
+    ["null", null, "not a plain object"],
+    [
+      "too few references",
+      { WEBIDL: { href: "h", title: "t" } },
+      "expected 80000+",
+    ],
+    [
+      "a sentinel missing its href",
+      { ...valid, WEBIDL: { title: "Web IDL" } },
+      "sentinel WEBIDL",
+    ],
+    [
+      "a broken alias chain",
+      { ...valid, ABNF: { aliasOf: "ELSEWHERE" } },
+      "alias chain broken",
+    ],
+    [
+      "an alias chain whose terminal record is missing",
+      { ...valid, rfc5234: undefined },
+      "sentinel rfc5234",
+    ],
+  ];
+
+  for (const [description, data, reason] of rejected) {
+    it(`rejects ${description}`, () => {
+      expect(validate(data)).withContext(description).toContain(reason);
+    });
+  }
+
+  it("accepts data that has everything it checks for", () => {
+    expect(validate(valid)).toBeNull();
+  });
+});

--- a/vendor/specref/LICENSE
+++ b/vendor/specref/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 Tobie Langel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/specref/README.md
+++ b/vendor/specref/README.md
@@ -1,0 +1,21 @@
+# Vendored from tobie/specref
+
+`bibref.js` and `format-date.js` are copied byte-for-byte from
+<https://github.com/tobie/specref>, Apache-2.0, at commit
+`fd96b31990dbddb2e93f40db2c1e9b3a19f9dfae`. `LICENSE` is that project's license
+text.
+
+```
+sha256  a6d61c66e0ac6e5433bdfe9d37d047788a74fcf04451667971d4fbe1b88316c9  bibref.js
+sha256  952e98ea622c0a8b44b5e13e47e303e5254086b01307703d15adff7b0981e186  format-date.js
+```
+
+`routes/bibrefs` runs these to turn the upstream `refs/*.json` into the map the
+service serves. Update them only by copying a newer upstream revision and
+changing the commit and hashes above; keeping them byte-identical is what makes
+that a readable diff.
+
+They sit outside `routes/` because `tsconfig.json` does not include this
+directory, and because this package is `"type": "module"` while these are
+CommonJS. The scraper copies them over the clone's own `lib/` before running
+anything, so a commit to upstream's code never executes here.

--- a/vendor/specref/bibref.js
+++ b/vendor/specref/bibref.js
@@ -1,0 +1,341 @@
+var fs = require('fs'),
+    path = require('path'),
+    url = require('url'),
+    formatDate = require('./format-date');
+
+var PROPS =  [
+    "id",
+    "authors",
+    "etAl",
+    "href",
+    "edDraft",
+    "title",
+    "date",
+    "status",
+    "publisher",
+    "pages",
+    "isbn",
+    "aliasOf",
+    "obsoletes",
+    "obsoletedBy",
+    "versions",
+    "versionOf",
+    "deliveredBy",
+    "repository"
+];
+
+var WG_SHORTNAME_SPECIAL_CASES = {
+    'graphics_svg': 'svg',
+    'graphics_webcgm': 'webcgm',
+    'markup': 'html-old',
+    'markup_coord': 'hypertextcg',
+    'markup_forms': 'forms',
+    'mobile_ccpp': 'ccpp',
+    'p3p_specification': 'p3p',
+    'style_css': 'css',
+    'style_xsl': 'xsl',
+    'xp': 'xml_protocol' 
+};
+
+var WG_REVERSE_INDEX = {
+    'https://www.dvb.org/': 'dvb',
+    'http://www.iso.org/iso/home/standards_development/list_of_iso_technical_committees/iso_technical_committee.htm?commid=45316':  'ISO_IEC-JTC-1_SC-29',
+    'http://www.opengeospatial.org': 'ogc',
+    'https://datatracker.ietf.org/wg/httpauth/': 'httpauth'
+};
+
+function _getWGShortNameFromURL(url) {
+    if (WG_REVERSE_INDEX[url]) {
+        return WG_REVERSE_INDEX[url];
+    }
+    var shortname = url.toLowerCase()
+             // Die, date space die!
+             .replace(/\/([0-9]+\/)+/g, '/')
+             .replace(/-?wg/,'')
+             .replace(/group/,'')
+             .replace(/members/,'')
+             .replace(/\.html/,'')
+             .replace(/community/,'cg')
+             .replace(/international/,'i18n')
+             // base url
+             .replace(/https?:\/\/www\.w3\.org\//, "")
+             .replace(/^https?:\/\//, "")
+             .replace(/\/+/g, '/')
+             // Trailing slash
+             .replace(/\/$/, '')
+             // convert / into _
+             .replace(/\//g, "_") ;
+    if (WG_SHORTNAME_SPECIAL_CASES[shortname]) {
+        return WG_SHORTNAME_SPECIAL_CASES[shortname];
+    }
+    return shortname;
+}
+
+function _copyProps(src, dest) {
+    for (var k in src) {
+        dest[k] = src[k];
+    }
+}
+
+function _cloneJSON(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function Bibref() {
+    this.raw = {};
+}
+
+Bibref.prototype.addRefs = addRefs;
+function addRefs(refs) {
+    if (this.all) {
+        throw new Error("Can no longer add references as Bibref.prototype.doneAddingRefs was called.");
+    }
+    _merge(this.raw, refs);
+}
+
+Bibref.prototype.doneAddingRefs = doneAddingRefs;
+function doneAddingRefs() {
+    this.all = cleanupRefs(addIds(createUppercaseRefs(expandRefs(this.raw))));
+    this.reverseLookupTable = prepareReverseLookup(this.all);
+}
+
+function _merge(target, source) {
+    for (var k in source) {
+        if (k in target) {
+            throw new Error("Duplicate entry " + k);
+        } else {
+            target[k] = source[k];
+        }
+    }
+}
+
+function normalizeUrl(u) {
+    // We treat different protocols as identical, so omit them from the
+    // output. Same for whatever's after the hash.
+    // Likewise, we consider trailing slashes optional and remove them
+    // when present (it's easier to remove a trailing slash than to add
+    // one where missing).
+    u = url.parse(u);
+    u = (u.hostname || "").replace(/^www\./, "") + (u.pathname || "").replace(/\/$/, "") + (u.search || "") + (u.hash || "");
+    // Case insensitive match.
+    return u.toLowerCase();
+}
+
+function prepareReverseLookup(refs) {
+    var output = {};
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
+        var href = ref.href;
+        if (href) {
+            href = normalizeUrl(href);
+            output[href] = refs[ref.versionOf || k];
+        }
+    });
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
+        var edDraft = ref.edDraft;
+        if (edDraft) {
+            edDraft = normalizeUrl(edDraft);
+            if (!(edDraft in output)) {
+                output[edDraft] = refs[ref.versionOf || k];
+            }
+        }
+    });
+    return output;
+}
+
+// Iterates through the reference looking for previous
+// versions of the spec which it makes available as:
+// KEY-SUBKEY (e.g. DAHUT-19970315).
+// Properties which are missing from the previous entry
+// fall back to props of the main entry.
+// Correctly forwards aliases. For example:
+// CSS2 is aliased to CSS21 therefore
+// CSS2-20110607 will automatically be aliased to
+// CSS21-20110607
+function expandRefs(refs) {
+    refs = _cloneJSON(refs);
+    Object.keys(refs).forEach(function(key) {
+        var ref = refs[key];
+        if (ref.aliasOf) {
+            var obj = ref,
+                lastKey = key;
+            while (obj && refs[obj.aliasOf]) {
+                lastKey = obj.aliasOf;
+                obj = refs[lastKey];
+            }
+        }
+        if (obj && key !== lastKey) {
+            obj.aliases = obj.aliases || [];
+            obj.aliases.push(key);
+        }
+    });
+
+    Object.keys(refs).forEach(function(key) {
+        var ref = refs[key];
+        var versions = ref.versions
+        if (versions) {
+            Object.keys(versions).forEach(function(subKey) {
+                var ver = versions[subKey];
+                if (ver.aliasOf) {
+                    refs[key + '-' + subKey] = ver;
+                } else {
+                    var obj = {
+                        versionOf: key
+                    };
+                    // Props fallback to main entry.
+                    _copyProps(ref, obj);
+                    _copyProps(ver, obj);
+                    delete obj.versions;
+                    delete obj.obsoletes;
+                    refs[key + '-' + subKey] = obj;
+                }
+            });
+            if (ref.aliases) {
+                ref.aliases.forEach(function(aliasKey) {
+                    if (refs[aliasKey].isSeriesAlias) {
+                        return;
+                    }
+                    Object.keys(versions).forEach(function(subKey) {
+                        // Watch out not to overwrite existing aliases.
+                        if (!refs[aliasKey + '-' + subKey]) {
+                            refs[aliasKey + '-' + subKey] = { aliasOf: key + '-' + subKey };
+                        }
+                    });
+                });
+            }
+        }
+    });
+    return refs;
+}
+
+// Creates uppercased aliases to allow case-insensitive retrieval
+function createUppercaseRefs(refs) {
+    Object.keys(refs).forEach(function(key) {
+        var upper = key.toUpperCase();
+        if (!refs[upper]) {
+            refs[upper] = { aliasOf: key };
+        }
+    });
+
+    return refs;
+}
+
+function cleanupRefs(refs) {
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
+        if (typeof ref === 'object') {
+            if (ref.rawDate) ref.date = formatDate(ref.rawDate);
+            for (var prop in ref) {
+                if (PROPS.indexOf(prop) === -1) {
+                    delete ref[prop];
+                }
+                if (prop == "deliveredBy") {
+                    ref.deliveredBy = ref.deliveredBy.map(function(url) {
+                        return { url: url, shortname: _getWGShortNameFromURL(url) };
+                    });
+                }
+                if (prop == "versions") {
+                    ref.versions = Object.keys(ref.versions).map(function(subKey) {
+                        return k + "-" + subKey;
+                    });
+                    ref.versions.sort();
+                    ref.versions.reverse();
+                }
+            }
+        }
+    });
+    return refs;
+}
+
+function addIds(refs) {
+    Object.keys(refs).forEach(function(k) {
+        var ref = refs[k];
+        if (typeof ref === 'object') {
+            ref.id = k;
+        }
+    });
+    return refs;
+}
+
+var EIGHT_DIGITS = /^\d{8}$/;
+
+function findLatest(ref) {
+    var keys, latest = null;
+    if (ref.versions) {
+        keys = Object.keys(ref.versions).filter(function(k) { return EIGHT_DIGITS.test(k); }).sort();
+        latest = ref.versions[keys[keys.length - 1]];
+    }
+    return latest;
+}
+
+Bibref.prototype.get = get;
+function get(ref, output) {
+    output = output || {};
+    var obj, versionOf, uRef;
+
+    // if ref doesn't exist but the uppercased key does, add an alias on the fly
+    if ((!this.all[ref]) && this.all[ref.toUpperCase()]) {
+        output[ref] = { aliasOf: ref.toUpperCase(), id: ref };
+        ref = ref.toUpperCase();
+    }
+
+    do {
+        obj = this.all[ref];
+        uRef = ref.toUpperCase();
+        // if ref doesn't exist but the uppercased key does, add an alias on the fly
+        if (!obj && !output[ref] && this.all[uRef]) {
+            output[ref] = { aliasOf: uRef, id: ref };
+            ref = uRef;
+            obj = this.all[ref];
+        }
+        if (obj && !output[ref]) output[ref] = obj;
+    } while (obj && (ref = obj.aliasOf))
+    if (obj && (versionOf = obj.versionOf)) {
+        output[versionOf] = this.all[versionOf];
+    }
+    return output;
+}
+
+Bibref.prototype.getRefs = getRefs;
+function getRefs(refs) {
+    var output = {};
+    refs.forEach(function(ref) { this.get(ref, output); }, this);
+    return output;
+}
+
+Bibref.prototype.reverseLookup = reverseLookup;
+function reverseLookup(urls) {
+    var output = {};
+    urls.forEach(function(url) {
+        var ref = this.reverseLookupTable[normalizeUrl(url || "")];
+        if (ref) output[url] = ref;
+    }, this);
+    return output;
+}
+
+var REFS_DIR = path.join(__dirname, '../refs');
+
+var b = new Bibref();
+fs.readdirSync(REFS_DIR).forEach(function(file) {
+    var content = fs.readFileSync(path.join(REFS_DIR, file), 'utf8');
+    var json = JSON.parse(content);
+    b.addRefs(json);
+});
+b.doneAddingRefs();
+
+module.exports = b;
+module.exports.create = function() {
+    var b = new Bibref();
+    for (var i = 0; i < arguments.length; i++) {
+        b.addRefs(arguments[i]);
+    }
+    b.doneAddingRefs();
+    return b;
+};
+module.exports.expandRefs = expandRefs;
+module.exports.createUppercaseRefs = createUppercaseRefs;
+module.exports.cleanupRefs = cleanupRefs;
+module.exports.findLatest = findLatest;
+module.exports.normalizeUrl = normalizeUrl;
+

--- a/vendor/specref/format-date.js
+++ b/vendor/specref/format-date.js
@@ -1,0 +1,32 @@
+module.exports = function(str) {
+    var date = str.split("-"),
+        y = date[0],
+        m = date[1],
+        d = date[2],
+        output = [];
+        
+    if (d) {
+        output.push(Number(d));
+    }
+    if (m) {
+        m = Number(m) - 1;
+        output.push(MONTHS[m]);
+    }
+    output.push(y);
+    return output.join(" ");
+};
+
+var MONTHS = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+];


### PR DESCRIPTION
api.specref.org has been offline since 30 August, so ReSpec documents render with unresolved references. This serves the same data from respec.org at GET /bibrefs, matching the dead service's request and response shape.

Needs speced/respec#5448 to point ReSpec at it; this endpoint alone changes nothing for documents.

Written with Claude: the route, scraper, store and tests are generated logic.
