### PR TITLE
fix(bibrefs): load the vendored transform when DATA_DIR is inside the checkout

### DIFF
--- a/routes/bibrefs/index.ts
+++ b/routes/bibrefs/index.ts
@@ -12,11 +12,9 @@ const MAX_REFERENCES_PER_REQUEST = 500;
 const CACHE_SECONDS = seconds("1h");
 
 /**
- * Two limits, because the two answers are wildly different sizes.
- *
- * A lookup replies with tens of kilobytes, so it can be generous. The whole
- * store is 26 MB, and its URL never varies, so a cache in front should absorb
- * nearly all of it; anything reaching us at volume is abuse, not a spec build.
+ * Two limits: a lookup answers with tens of kilobytes, the whole store with
+ * 26 MB. That URL never varies, so a cache in front should absorb almost all of
+ * it and volume reaching us is abuse rather than spec builds.
  */
 const lookupRateLimit = rateLimit({
   windowMs: ms("1m"),
@@ -76,15 +74,17 @@ export function route(req: Request, res: Response) {
   });
 
   setCacheHeaders(res);
-  // jsonp, not json: the service this replaces answered `?callback=` with
-  // JSONP, and Express falls back to plain JSON when no callback is named.
+  // jsonp, not json: keeps `?callback=` working, and is plain JSON without it.
   res.jsonp(body);
 }
 
-/** Only a request with no query string. `?refs=` and `?refs[]=a` leave
- * `req.query.refs` empty, so testing that instead gives the store away. */
+/**
+ * Only a request naming nothing to look up. `?refs=` and `?refs[]=a` leave
+ * `req.query.refs` empty, so testing that instead gives the store away.
+ * `callback` picks a format rather than content, so it does not count.
+ */
 function wantsWholeStore(req: Request) {
-  return Object.keys(req.query).length === 0;
+  return Object.keys(req.query).every(key => key === "callback");
 }
 
 /** `?refs=A,B&refs=C` becomes ["A", "B", "C"]. */

--- a/routes/bibrefs/lib/build-data.ts
+++ b/routes/bibrefs/lib/build-data.ts
@@ -1,28 +1,14 @@
-// Spawned by lib/scraper.ts as its own process, because the transform it runs
-// peaks near 560 MB and a worker thread would charge that to the server.
+// Keep this out of the server process: the transform it runs peaks near 560 MB.
 //
 // Runnable by hand to rebuild the data file without restarting the server:
 //   node build/routes/bibrefs/lib/build-data.js <cloneDirectory> <outputFile>
 
 import { createRequire } from "node:module";
-import {
-  copyFileSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { lstatSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-import { PROJECT_ROOT } from "../../../utils/constants.js";
 import { validate } from "./validate.js";
-
-const VENDOR_DIRECTORY = path.join(PROJECT_ROOT, "vendor", "specref");
-const TRANSFORM = "bibref.js";
-const VENDORED_FILES = [TRANSFORM, "format-date.js"];
+import { prepareWorkspace } from "./workspace.js";
 
 /** Symlinks survive a clone, and the transform reads every file in here. */
 function assertEveryInputIsAPlainJsonFile(directory: string) {
@@ -38,45 +24,19 @@ function assertEveryInputIsAPlainJsonFile(directory: string) {
   }
 }
 
-/**
- * Build a directory we own for the transform to run in, and return the file to
- * require.
- *
- * The transform reads its input from `__dirname/../refs`, so it needs a parent
- * holding both. Nothing is written inside the clone: every path there belongs to
- * upstream, and a committed symlink would otherwise let a copy land wherever it
- * pointed.
- */
-function prepareWorkspace(cloneDirectory: string, outputFile: string) {
-  const workspace = path.join(path.dirname(outputFile), "transform");
-  rmSync(workspace, { recursive: true, force: true });
-  mkdirSync(path.join(workspace, "lib"), { recursive: true });
-  for (const name of VENDORED_FILES) {
-    copyFileSync(
-      path.join(VENDOR_DIRECTORY, name),
-      path.join(workspace, "lib", name),
-    );
-  }
-  symlinkSync(path.join(cloneDirectory, "refs"), path.join(workspace, "refs"));
-  return path.join(workspace, "lib", TRANSFORM);
-}
-
 function build(cloneDirectory: string, outputFile: string) {
   assertEveryInputIsAPlainJsonFile(path.join(cloneDirectory, "refs"));
   const transform = prepareWorkspace(cloneDirectory, outputFile);
   const bibref = createRequire(import.meta.url)(transform);
   const references = bibref.all;
 
-  // The transform keeps its merged input and a reverse-lookup index alive next
-  // to the result. Nothing here reads either, and together they are most of the
-  // peak this process reaches.
+  // Most of this process's peak, and nothing here reads them.
   bibref.raw = null;
   bibref.reverseLookupTable = null;
 
   const problem = validate(references);
   if (problem) throw new Error(`Refusing to publish: ${problem}.`);
 
-  // Rename, so a crash mid-write cannot leave a truncated file to load at boot.
   const temporary = `${outputFile}.incoming`;
   writeFileSync(temporary, JSON.stringify(references), "utf8");
   renameSync(temporary, outputFile);

--- a/routes/bibrefs/lib/refresh.ts
+++ b/routes/bibrefs/lib/refresh.ts
@@ -16,7 +16,12 @@ async function tick() {
   }
 }
 
-/** setTimeout, not setInterval: a slow run must not overlap the next one. */
+/**
+ * setTimeout, not setInterval: a slow run must not overlap the next one.
+ *
+ * Schedule only, never fetch here: this runs when the route is imported, so a
+ * fetch clones specref on every test run.
+ */
 export function startRefreshing() {
   setTimeout(tick, ms("1h")).unref();
 }

--- a/routes/bibrefs/lib/scraper.ts
+++ b/routes/bibrefs/lib/scraper.ts
@@ -16,18 +16,15 @@ const CLONE_DIRECTORY = path.resolve(env("DATA_DIR"), "specref");
 const GIT_TIMEOUT = ms("10m");
 const BUILD_TIMEOUT = ms("2m");
 // Keep this. A smaller old-generation budget makes V8 collect sooner, which
-// measurably lowers the peak resident memory of a build that runs beside the
-// server on a host with about a gigabyte.
+// lowers peak resident memory on a host the server is also using.
 const BUILD_HEAP_MB = 512;
 const defaultOptions = { forceUpdate: false };
 type Options = typeof defaultOptions;
 
 /**
- * The commit whose data we last wrote out successfully.
- *
- * Compared against, rather than "did the clone move", so a build that fails
- * after the clone has already advanced gets retried instead of being treated as
- * up to date until upstream happens to commit again.
+ * The commit whose data we last wrote out successfully. Set only after a build
+ * succeeds, so a build that fails once the clone has already advanced is
+ * retried rather than treated as up to date.
  */
 let lastPublishedCommit: string | null = null;
 
@@ -84,9 +81,8 @@ async function updateInputSource() {
     await git(["clean", "-fd"], CLONE_DIRECTORY);
     return await head();
   } catch (error) {
-    // An interrupted fetch leaves an index.lock that fails every later run, and
+    // An interrupted fetch leaves an index.lock that fails every later run;
     // an interrupted clone leaves a directory that is not a repository at all.
-    // Reading the commit inside this block is what lets the second case recover.
     console.warn(
       "specref: git failed, discarding the clone and starting over.",
       error,
@@ -97,9 +93,10 @@ async function updateInputSource() {
   }
 }
 
-/** Its own process: a worker thread shares this process's resident memory, and the transform peaks near 560 MB. */
+/** Its own process: a worker thread would share this process's memory. */
 async function buildData() {
   const script = path.join(import.meta.dirname, "build-data.js");
+  const { PATH, HOME } = process.env;
   const { stdout } = await run(
     process.execPath,
     [
@@ -108,7 +105,9 @@ async function buildData() {
       CLONE_DIRECTORY,
       DATA_FILE,
     ],
-    { timeout: BUILD_TIMEOUT },
+    // Same allowlist as git: this child runs third-party code over third-party
+    // data, so it must not inherit GH_TOKEN or the webhook secrets.
+    { timeout: BUILD_TIMEOUT, env: { PATH, HOME } },
   );
   console.log(stdout.trim());
 }

--- a/routes/bibrefs/lib/store.ts
+++ b/routes/bibrefs/lib/store.ts
@@ -53,9 +53,8 @@ export class Store {
  * `[[webidl]]` finds the entry stored under `WEBIDL`. Unknown keys are left out.
  */
 export function getRefs(references: References, keys: string[]): References {
-  // No prototype while it is being filled, so assigning a key can never
-  // re-point one. Safe only because collect refuses the keys that would
-  // otherwise land here as real properties.
+  // No prototype while filling, so assigning a key cannot re-point one. Safe
+  // only because collect refuses the keys that would become real properties.
   const output: References = Object.create(null);
   for (const key of keys) collect(references, key, output);
   // Copy before returning. An object built by assigning keys one at a time ends

--- a/routes/bibrefs/lib/validate.ts
+++ b/routes/bibrefs/lib/validate.ts
@@ -19,12 +19,9 @@ export type References = Record<string, Reference>;
 export const SMALLEST_PLAUSIBLE_DATABASE = 80_000;
 
 /**
- * Reference identifiers we refuse to look up or to answer with.
- *
- * Assigning one of these onto a response object either re-points its prototype
- * or, on a null-prototype object, becomes a real key the client receives. The
- * upstream data could carry `aliasOf: "__proto__"` as easily as a caller could
- * ask for it, so this is checked at both ends.
+ * Reference identifiers we refuse to look up or to answer with. Checked at both
+ * ends, because the data can carry `aliasOf: "__proto__"` as easily as a caller
+ * can ask for it.
  */
 const UNSAFE_KEY = /^(?:__proto__|constructor|prototype)$/i;
 

--- a/routes/bibrefs/lib/workspace.ts
+++ b/routes/bibrefs/lib/workspace.ts
@@ -1,0 +1,44 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { PROJECT_ROOT } from "../../../utils/constants.js";
+
+const VENDOR_DIRECTORY = path.join(PROJECT_ROOT, "vendor", "specref");
+export const TRANSFORM = "bibref.js";
+const VENDORED_FILES = [TRANSFORM, "format-date.js"];
+
+/**
+ * Build a directory we own for the vendored transform to run in, and return the
+ * file to require.
+ *
+ * It needs a parent holding both `lib` and `refs`, because it reads its input
+ * from `__dirname/../refs`. Write nothing inside the clone: a committed symlink
+ * there would send a copy wherever it pointed.
+ */
+export function prepareWorkspace(cloneDirectory: string, outputFile: string) {
+  const workspace = path.join(path.dirname(outputFile), "transform");
+  rmSync(workspace, { recursive: true, force: true });
+  mkdirSync(path.join(workspace, "lib"), { recursive: true });
+  // The transform is CommonJS and this package is "type": "module". Without
+  // this, a workspace anywhere under the checkout makes Node find the project's
+  // package.json first and refuse to load it.
+  writeFileSync(
+    path.join(workspace, "package.json"),
+    JSON.stringify({ type: "commonjs" }),
+    "utf8",
+  );
+  for (const name of VENDORED_FILES) {
+    copyFileSync(
+      path.join(VENDOR_DIRECTORY, name),
+      path.join(workspace, "lib", name),
+    );
+  }
+  symlinkSync(path.join(cloneDirectory, "refs"), path.join(workspace, "refs"));
+  return path.join(workspace, "lib", TRANSFORM);
+}

--- a/tests/routes/bibrefs/route.test.js
+++ b/tests/routes/bibrefs/route.test.js
@@ -124,6 +124,12 @@ describe("routes/bibrefs - route", () => {
     });
   }
 
+  it("still sends the whole database when only a jsonp callback is named", () => {
+    // Answering callback({}) to a request for everything is a wrong answer
+    // dressed as a valid one.
+    expect(call({ callback: "myFunc" })._sentFile).toBe(DATA_FILE);
+  });
+
   it("sends the whole database only for a bare GET, as Bikeshed expects", () => {
     // The exact path: a tail-anchored match passes for the wrong directory.
     expect(call({})._sentFile).toBe(DATA_FILE);

--- a/tests/routes/bibrefs/workspace.test.js
+++ b/tests/routes/bibrefs/workspace.test.js
@@ -1,0 +1,32 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { prepareWorkspace } from "../../../build/routes/bibrefs/lib/workspace.js";
+
+describe("routes/bibrefs - build workspace", () => {
+  let root;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "bibrefs-workspace-"));
+  });
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("declares itself CommonJS so the vendored transform loads", () => {
+    // This package is "type": "module". Without the declaration, a DATA_DIR
+    // inside the checkout makes Node treat the transform as ESM and refuse it,
+    // which is how it failed in production while passing here.
+    const transform = prepareWorkspace(
+      path.join(root, "clone"),
+      path.join(root, "out", "biblio.json"),
+    );
+    const manifest = path.join(
+      path.dirname(path.dirname(transform)),
+      "package.json",
+    );
+    expect(JSON.parse(readFileSync(manifest, "utf8")).type).toBe("commonjs");
+  });
+});


### PR DESCRIPTION
prestart crashes on the server: the build workspace sits under DATA_DIR, so when that is inside the checkout Node finds this package's "type": "module" and refuses to load the vendored CommonJS transform. The workspace now declares itself CommonJS, the transform child gets the same environment allowlist as git rather than inheriting GH_TOKEN and the webhook secrets, and a bare `?callback=` returns the whole database again instead of an empty object.

Written with Claude: all of it.
